### PR TITLE
Switching to JSDoc syntax

### DIFF
--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -4,16 +4,96 @@
 var _cf = _cf || [],
   /**
    * @namespace
-   * @property {number} ver           - Akamai version, e.g: 1.7
-   * @property {number} ke_cnt_lmt    - Max keyboard event limit
-   * @property {number} mme_cnt_lmt   - Max mouse move event limit
-   * @property {number} mduce_cnt_lmt - Max mouse down/up event limit
-   * @property {number} pme_cnt_lmt   - 
-   * @property {number} pduce_cnt_lmt - Max pointer event limit
-   * @property {number} tme_cnt_lmt   - Touch move event limit
-   * @property {number} doe_cnt_lmt   - Device orientation event limit
-   * @property {number} dme_cnt_lmt   - Device motion event limit
-   * @property {number} vc_cnt_lmt    - Visibility change count limit
+   * @property {number} ver                     - Akamai version, e.g: 1.7
+   * @property {number} ke_cnt_lmt              - Max keyboard event limit
+   * @property {number} mme_cnt_lmt             - Max mouse move event limit
+   * @property {number} mduce_cnt_lmt           - Max mouse down/up event limit
+   * @property {number} pme_cnt_lmt             - 
+   * @property {number} pduce_cnt_lmt           - Max pointer event limit
+   * @property {number} tme_cnt_lmt             - Touch move event limit
+   * @property {number} doe_cnt_lmt             - Device orientation event limit
+   * @property {number} dme_cnt_lmt             - Device motion event limit
+   * @property {number} vc_cnt_lmt              - Visibility change count limit
+   * @property {number} doa_throttle
+   * @property {number} dma_throttle
+   * @property {string} session_id
+   * @property {boolean | number} js_post
+   * @property {string} loc
+   * @property {string} cf_url
+   * @property {string} params_url
+   * @property {string} auth
+   * @property {string} api_public_key
+   * @property {number} aj_lmt_doact
+   * @property {number} aj_lmt_dmact
+   * @property {number} aj_lmt_tact
+   * @property {number} ce_js_post
+   * @property {number} init_time
+   * @property {string} informinfo
+   * @property {number} prevfid
+   * @property {number} fidcnt
+   * @property sensor_data
+   * @property ins
+   * @property cns
+   * @property {number} enGetLoc
+   * @property {number} enReadDocUrl
+   * @property {number} disFpCalOnTimeout
+   * @property {number} xagg
+   * @property {number} pen
+   * @property {string} brow
+   * @property {string} browver
+   * @property {string} psub
+   * @property {string} lang
+   * @property {string} prod
+   * @property {number} plen
+   * @property {number} doadma_en
+   * @property sdfn
+   * @property {number} d2
+   * @property {number} d3
+   * @property {number} thr
+   * @property {string} cs
+   * @property {string} hn
+   * @property {number} z1
+   * @property {number} o9
+   * @property vc
+   * @property {number} y1
+   * @property {number} ta
+   * @property {number} tst
+   * @property {number} t_tst
+   * @property {string} ckie                    -  
+   * @property n_ck
+   * @property {number} ckurl
+   * @property bm
+   * @property {string} mr
+   * @property altFonts
+   * @property rst
+   * @property runFonts
+   * @property fsp
+   * @property firstLoad
+   * @property pstate
+   * @property {number} mn_mc_lmt
+   * @property {number} mn_state
+   * @property {number} mn_mc_indx
+   * @property {number} mn_sen
+   * @property {number} mn_tout
+   * @property {number} mn_stout
+   * @property {number} mn_ct
+   * @property {string} mn_cc
+   * @property {number} mn_cd
+   * @property mn_lc
+   * @property mn_ld
+   * @property {number} mn_lcl
+   * @property mn_al
+   * @property mn_il
+   * @property mn_tcl
+   * @property mn_r
+   * @property {number} mn_rt
+   * @property {number} mn_wt
+   * @property {string} mn_abck
+   * @property {string} mn_psn
+   * @property {string} mn_ts
+   * @property mn_lg
+   * @property {number} loap
+   * @property {number} dcs
    */
   bmak = bmak && bmak.hasOwnProperty("ver") && bmak.hasOwnProperty("sed") ? bmak : {
     ver: 1.7,

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -2,18 +2,31 @@
   Akamai version 1.7 grabbed from YeezySupply
 */
 var _cf = _cf || [],
+  /**
+   * @namespace
+   * @property {number} ver           - Akamai version, e.g: 1.7
+   * @property {number} ke_cnt_lmt    - Max keyboard event limit
+   * @property {number} mme_cnt_lmt   - Max mouse move event limit
+   * @property {number} mduce_cnt_lmt - Max mouse down/up event limit
+   * @property {number} pme_cnt_lmt   - 
+   * @property {number} pduce_cnt_lmt - Max pointer event limit
+   * @property {number} tme_cnt_lmt   - Touch move event limit
+   * @property {number} doe_cnt_lmt   - Device orientation event limit
+   * @property {number} dme_cnt_lmt   - Device motion event limit
+   * @property {number} vc_cnt_lmt    - Visibility change count limit
+   */
   bmak = bmak && bmak.hasOwnProperty("ver") && bmak.hasOwnProperty("sed") ? bmak : {
-    ver: 1.7, // Akamai version 1.7
-    ke_cnt_lmt: 150, // Max keyboard event limit
-    mme_cnt_lmt: 100, // Max mouse move event limit
-    mduce_cnt_lmt: 75, // Max mouse down/up event limit
+    ver: 1.7,
+    ke_cnt_lmt: 150,
+    mme_cnt_lmt: 100,
+    mduce_cnt_lmt: 75,
     pme_cnt_lmt: 25,
-    pduce_cnt_lmt: 25, // Max pointer event limit
-    tme_cnt_lmt: 25, // Touch move event limit
-    tduce_cnt_lmt: 25, // Other touch event limit
-    doe_cnt_lmt: 10, // Device orientation event limit
-    dme_cnt_lmt: 10, // Device motion event limit
-    vc_cnt_lmt: 100, // Visibility change count limit
+    pduce_cnt_lmt: 25,
+    tme_cnt_lmt: 25,
+    tduce_cnt_lmt: 25,
+    doe_cnt_lmt: 10,
+    dme_cnt_lmt: 10,
+    vc_cnt_lmt: 100,
     doa_throttle: 0, 
     dma_throttle: 0,
     session_id: "default_session",
@@ -293,17 +306,19 @@ var _cf = _cf || [],
       }
     },
     
-    /*
-      Check if the user is using the Brave browser.
-      The navigator.brave property only exists on
-      Brave browsers.
-
-      Brave is a Chromium basedprivacy browser that 
-      blocks trackers and enables some privacy settings.
-
-      They can potentially use this check to loosen
-      fingerprinting requirements if Brave is detected.
-    */
+    
+    /**
+     * 
+     * Check if the user is using the Brave browser.
+     * The navigator.brave property only exists on
+     * Brave browsers.
+     *
+     * Brave is a Chromium basedprivacy browser that 
+     * blocks trackers and enables some privacy settings.
+     *
+     * They can potentially use this check to loosen
+     * fingerprinting requirements if Brave is detected.
+     */
     gbrv: function() {
       navigator.brave && navigator.brave.isBrave().then(function(t) {
         bmak.brv = t ? 1 : 0;

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -828,46 +828,46 @@ var _cf = _cf || [],
       return t.push("x12:" + u), t.join(",");
     },
     
-    /*
-      Create a bit field checking for the existence of the following properties
-      0: navigator.credentials
-      1: navigator.appMinorVersion
-      2: navigator.bluetooth
-      3: navigator.storage
-      4: Math.imul
-      5: navigator.getGamepads
-      6: navigator.getStorageUpdates
-      7: navigator.getStorageUpdates
-      8: navigator.hardwareConcurrency
-      9: navigator.mediaDevices
-      10: navigator.mozAlarms
-      11: navigator.mozConnection
-      12: navigator.mozIsLocallyAvailable
-      13: navigator.mozPhoneNumberService
-      14: navigator.msManipulationViewsEnabled
-      15: navigator.permissions
-      16: navigator.registerProtocolHandler
-      17: navigator.requestMediaKeySystemAccess
-      18: navigator.requestWakeLock
-      19: navigator.sendBeacon
-      20: navigator.serviceWorker
-      21: navigator.storeWebWideTrackingException
-      22: navigator.webkitGetGamepads
-      23: navigator.webkitTemporaryStorage
-      24: Number.parseInt
-      25: Math.hypot
+    /**
+     * Create a bit field checking for the existence of the following properties     
+     *  0: navigator.credentials     
+     *  1: navigator.appMinorVersion     
+     *  2: navigator.bluetooth     
+     *  3: navigator.storage     
+     *  4: Math.imul     
+     *  5: navigator.getGamepads     
+     *  6: navigator.getStorageUpdates     
+     *  7: navigator.getStorageUpdates     
+     *  8: navigator.hardwareConcurrency     
+     *  9: navigator.mediaDevices     
+     *  10: navigator.mozAlarms     
+     *  11: navigator.mozConnection     
+     *  12: navigator.mozIsLocallyAvailable     
+     *  13: navigator.mozPhoneNumberService     
+     *  14: navigator.msManipulationViewsEnabled          
+     *  15: navigator.permissions     
+     *  16: navigator.registerProtocolHandler     
+     *  17: navigator.requestMediaKeySystemAccess     
+     *  18: navigator.requestWakeLock     
+     *  19: navigator.sendBeacon     
+     *  20: navigator.serviceWorker     
+     *  21: navigator.storeWebWideTrackingException     
+     *  22: navigator.webkitGetGamepads     
+     *  23: navigator.webkitTemporaryStorage     
+     *  24: Number.parseInt     
+     *  25: Math.hypot     
 
-      Running this function on my current machine on Chrome
-      returns the number 30261693 while on Safari returns 26018161
+     *  Running this function on my current machine on Chrome     
+     *  returns the number 30261693 while on Safari returns 26018161     
 
-      Converting these numbers to binary allows you to see which properties
-      exist and don't in your browser.
-
-      (The first bit from the left specifies whether Math.hypot exists and the last bit is navigator.credentials)
-      30261693: 1 1 1 0 0 1 1 0 1 1 1 0 0 0 0 0 1 1 0 1 1 1 1 0 1
-      26018161: 1 1 0 0 0 1 1 0 1 0 0 0 0 0 0 0 1 0 1 1 1 0 0 0 1
-
-    */
+     *  Converting these numbers to binary allows you to see which properties     
+     *  exist and don't in your browser.     
+     *  
+     *  (The first bit from the left specifies whether Math.hypot exists and the last bit is navigator.credentials)     
+     *  30261693: 1 1 1 0 0 1 1 0 1 1 1 0 0 0 0 0 1 1 0 1 1 1 1 0 1     
+     *  26018161: 1 1 0 0 0 1 1 0 1 0 0 0 0 0 0 0 1 0 1 1 1 0 0 0 1     
+     * @returns {number} bit field
+     */
     fas: function() {
       try {
         return Boolean(navigator.credentials) + (Boolean(navigator.appMinorVersion) << 1) + (Boolean(navigator.bluetooth) << 2) + (Boolean(navigator.storage) << 3) + (Boolean(Math.imul) << 4) + (Boolean(navigator.getGamepads) << 5) + (Boolean(navigator.getStorageUpdates) << 6) + (Boolean(navigator.hardwareConcurrency) << 7) + (Boolean(navigator.mediaDevices) << 8) + (Boolean(navigator.mozAlarms) << 9) + (Boolean(navigator.mozConnection) << 10) + (Boolean(navigator.mozIsLocallyAvailable) << 11) + (Boolean(navigator.mozPhoneNumberService) << 12) + (Boolean(navigator.msManipulationViewsEnabled) << 13) + (Boolean(navigator.permissions) << 14) + (Boolean(navigator.registerProtocolHandler) << 15) + (Boolean(navigator.requestMediaKeySystemAccess) << 16) + (Boolean(navigator.requestWakeLock) << 17) + (Boolean(navigator.sendBeacon) << 18) + (Boolean(navigator.serviceWorker) << 19) + (Boolean(navigator.storeWebWideTrackingException) << 20) + (Boolean(navigator.webkitGetGamepads) << 21) + (Boolean(navigator.webkitTemporaryStorage) << 22) + (Boolean(Number.parseInt) << 23) + (Boolean(Math.hypot) << 24);
@@ -876,10 +876,11 @@ var _cf = _cf || [],
       }
     },
     
-    /*
-    This function gets an average of performance metrics by
-    running various Math and JSON functions several times.
-    */
+    /**
+     * This function gets an average of performance metrics by
+     * running various Math and JSON functions several times.
+     * @returns 
+     */
     getmr: function() {
       try {
         if ("undefined" == typeof performance || void 0 === performance.now || "undefined" == typeof JSON) return void(bmak.mr = "undef");
@@ -912,49 +913,69 @@ var _cf = _cf || [],
       }
     },
     
-    /*
-      Checks for a series of properties that only exist while using
-      browser driver automation libraries. 
-
-      see: https://themerkle.com/selenium-java-how-to-avoid-bot-detection-by-websites-when-using-chromedriver-exe/
-      see: https://stackoverflow.com/a/24965280
-    */
+    /**
+     * Checks for a series of properties that only exist while using
+     * browser driver automation libraries.      
+     * 
+     * default values to avoid being detected as a bot     
+     * return "0,0,0,0,1,0,0"
+     * @see https://themerkle.com/selenium-java-how-to-avoid-bot-detection-by-websites-when-using-chromedriver-exe/
+     * @see https://stackoverflow.com/a/24965280
+     * @returns 
+     */
     sed: function() {
+      /**
+       * Property that exists when using chromedriver
+       * @property {string}
+       */
       var t;
-      // Property that exists when using chromedriver
       t = window.$cdc_asdjflasutopfhvcZLmcfl_ || document.$cdc_asdjflasutopfhvcZLmcfl_ ? "1" : "0";
+      /**
+       * Selenium webdriver
+       * @property {string}
+       */
       var a;
-      // Selenium webdriver
       a = null != window.document.documentElement.getAttribute("webdriver") ? "1" : "0";
+      /**
+       * Selenium webdriver
+       * @property {string}
+       */
       var e;
-      // Selenium webdriver
       e = void 0 !== navigator.webdriver && navigator.webdriver ? "1" : "0";
+      /**
+       * Selenium webdriver
+       * @property {string}
+       */
       var n;
-      // Selenium webdriver
       n = void 0 !== window.webdriver ? "1" : "0";
       var o;
       o = void 0 !== window.XPathResult || void 0 !== document.XPathResult ? "1" : "0";
+      /**
+       * Selenium webdriver
+       * @property {string}
+       */
       var m;
-      // Selenium webdriver
       m = null != window.document.documentElement.getAttribute("driver") ? "1" : "0";
+      /**
+       * Selenium webdriver
+       * @property {string}
+       */
       var r;
-      // Selenium webdriver
       return r = null != window.document.documentElement.getAttribute("selenium") ? "1" : "0", [t, a, e, n, o, m, r].join(",");
-
-      // default values to avoid being detected as a bot
-      // return "0,0,0,0,1,0,0"
     },
     
-    /*
-      Mouse events.
-
-      This function gets triggered on:
-      
-      hmm: "mousemove", "onmousemove" (a = 1)
-      hc: "click", "onclick" (a = 2)
-      hmd: "mousedown", "onmousedown" (a = 3)
-      hmu: "mouseup", "onmouseup" (a = 4)
-    */
+    /**
+     * Mouse events.
+     * 
+     *  This function gets triggered on:
+     *  
+     *  hmm: "mousemove", "onmousemove" (a = 1)
+     *  hc: "click", "onclick" (a = 2)
+     *  hmd: "mousedown", "onmousedown" (a = 3)
+     *  hmu: "mouseup", "onmouseup" (a = 4)
+     * @param {event} t @see https://dom.spec.whatwg.org/#concept-event
+     * @param {number} a 
+     */
     cma: function(t, a) {
       try {
         
@@ -964,6 +985,10 @@ var _cf = _cf || [],
           OR any click/mousedown/mouseup events and the event count is less than the mouse click event limit (75)
         */
         if (1 == a && bmak.mme_cnt < bmak.mme_cnt_lmt || 1 != a && bmak.mduce_cnt < bmak.mduce_cnt_lmt) {
+          /**
+           * The event triggered
+           * @see https://dom.spec.whatwg.org/#concept-event
+           */
           var e = t || window.event,
             n = -1,
             o = -1;
@@ -989,12 +1014,13 @@ var _cf = _cf || [],
       } catch (t) {}
     },
     
-    /*
-      Another one of Akamai's obfuscated ways of
-      return current timestamp in milliseconds.
+    /**
+     * Another one of Akamai's obfuscated ways of
+     *  return current timestamp in milliseconds.
 
-      It calls bmak.get_cf_date which returns Date.now()
-    */
+     *  It calls bmak.get_cf_date which returns Date.now()
+     * @returns {number}
+     */
     x2: function() {
         // bmak.ff = String.fromCharCode
         var t = bmak.ff,
@@ -1007,28 +1033,28 @@ var _cf = _cf || [],
       return "function" == typeof n && (o = n()), o;
     },
     
-    /*
-      Queries a bunch of permissions and maps into an array that
-      states whether the permission was
-      prompted (1)
-      granted (2)
-      denied (0)
-      invalid permission name (4)
-      Other error (3)
-
-      The array is then joined together to become a stringified number.
-
-      On my Chrome this function sets bmak.nav_perm to 
-      "11321144241322243122" but if navigator.permissions 
-      does not exist like on Safari nav_perm is set to 6
-
-      If the function fails for another reason then nav_perm
-      is set to 7
-
-      This can be used as a browser & fingerprinting check because:
-      -  Permissions don't exist on safari
-      -  Different browser's / users will have different permission configurations
-    */
+    /**
+     * Queries a bunch of permissions and maps into an array that states whether the permission was:    
+     *  - prompted (1)    
+     *  - granted (2)    
+     *  - denied (0)    
+     *  - invalid permission name (4)    
+     *  - Other error (3)    
+     * 
+     *  The array is then joined together to become a stringified number.
+     * 
+     *  On my Chrome this function sets bmak.nav_perm to 
+     *  "11321144241322243122" but if navigator.permissions 
+     *  does not exist like on Safari nav_perm is set to 6.
+     * 
+     *  If the function fails for another reason then nav_perm
+     *  is set to 7
+     * 
+     *  This can be used as a browser & fingerprinting check because:    
+     *  -  Permissions don't exist on safari    
+     *  -  Different browser's / users will have different permission configurations
+     * @returns 
+     */
     np: function() {
       var t = [],
         a = ["geolocation", "notifications", "push", "midi", "camera", "microphone", "speaker", "device-info", "background-sync", "bluetooth", "persistent-storage", "ambient-light-sensor", "accelerometer", "gyroscope", "magnetometer", "clipboard", "accessibility-events", "clipboard-read", "clipboard-write", "payment-handler"];
@@ -1073,16 +1099,18 @@ var _cf = _cf || [],
       }
     },
     
-    /*
-      This function handles pointer events.
-      Pointer events can be triggered by pen/stylus
-      or touch devices (see: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)
-
-      The events that trigger this function:
-
-      hpd: "pointerdown", "onpointerdown" (a = 3)
-      hpu: "pointerup", "onpointerup" (a = 4)
-    */
+    /**
+     * This function handles pointer events.
+     * Pointer events can be triggered by pen/stylus
+     *  or touch devices (see: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)
+     * 
+     *  The events that trigger this function:
+     * 
+     *  hpd: "pointerdown", "onpointerdown" (a = 3)
+     *  hpu: "pointerup", "onpointerup" (a = 4)
+     * @param {event} t 
+     * @param {number} a 
+     */
     cpa: function(t, a) {
       try {
         var e = !1;
@@ -1112,21 +1140,23 @@ var _cf = _cf || [],
       } catch (t) {}
     },
     
-    /*
-      Takes in a string as a parameter
-      Iterates over the string
-      and returns an accumulator of the
-      character codes less than 128
-      (non-extended ASCII codes)
-
-      Example:
-        bmak.ab("a")   // 97
-        bmak.ab("b")   // 98
-        bmak.ab("c")   // 99
-        bmak.ab("abc") // 294 (97 + 98 + 99)
-
-      https://www.rapidtables.com/code/text/ascii-table.html
-    */
+    /**
+     * Takes in a string as a parameter
+     *  Iterates over the string
+     *  and returns an accumulator of the
+     *  character codes less than 128
+     *  (non-extended ASCII codes)
+     * 
+     *  Example:     
+     *   -  bmak.ab("a")   // 97     
+     *   -  bmak.ab("b")   // 98     
+     *   -  bmak.ab("c")   // 99     
+     *   -  bmak.ab("abc") // 294 (97 + 98 + 99)
+     * 
+     * @see https://www.rapidtables.com/code/text/ascii-table.html
+     * @param {*} t 
+     * @returns 
+     */
     ab: function(t) {
       if (null == t) return -1;
 

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -1171,16 +1171,20 @@ var _cf = _cf || [],
         return -2;
       }
     },
-    // fromCharCode alias
+    
+    /**
+     * fromCharCode alias
+     * @param {number[]} t the char code
+     * @returns a string from the char code
+     */
     ff: function(t) {
       return String.fromCharCode(t);
     },
     
-    /*
-      Distance formula
-      https://www.varsitytutors.com/hotmath/hotmath_help/topics/distance-formula-in-3d
-
-    */
+    /**
+     * Distance formula
+     * @see https://www.varsitytutors.com/hotmath/hotmath_help/topics/distance-formula-in-3d
+     */
     cal_dis: function(t) {
       var a = t[0] - t[1],
         e = t[2] - t[3],
@@ -1188,6 +1192,10 @@ var _cf = _cf || [],
         o = Math.sqrt(a * a + e * e + n * n);
       return Math.floor(o);
     },
+
+    /**
+     * 
+     */
     to: function() {
       var t = bmak.x2() % 1e7;
       bmak.d3 = t;
@@ -1204,19 +1212,26 @@ var _cf = _cf || [],
       bmak.o9 = a * e;
     },
     
-    /*
-      The t parameter is the start timestamp (start_ts)
-      Original function:
-      jrs: function(t) {
-        for (var a = Math.floor(1e5 * Math.random() + 1e4), e = String(t * a), n = 0, o = [], m = e.length >= 18; o.length < 6;) o.push(parseInt(e.slice(n, n + 2))), n = m ? n + 3 : n + 2;
-
-        return [a, bmak.cal_dis(o)];
-      }
-    */
+    /**
+     * @param {*} t start timestamp (start_ts)
+     * @returns 
+     */
     jrs: function(t) {
-      // Generate a number between 10,000 and 110,000
+      /**
+       * Original function:     
+       *  jrs: function(t) {     
+       *      for (var a = Math.floor(1e5 * Math.random() + 1e4), e = String(t * a), n = 0, o = [], m = e.length >= 18; o.length < 6;) o.push(parseInt(e.slice(n, n + 2))), n = m ? n + 3 : n + 2;     
+       *      return [a, bmak.cal_dis(o)];     
+       *  }
+       */
+      /**
+       * Generate a number between 10,000 and 110,000
+       */
       var a = Math.floor(1e5 * Math.random() + 1e4);
-      var e = String(t * a); // start_ts * the random number stringified
+      /**
+       * start_ts * the random number stringified
+       */
+      var e = String(t * a);
       var n = 0;
       var o = [];
       var m = e.length >= 18;
@@ -1232,14 +1247,14 @@ var _cf = _cf || [],
       return [a, bmak.cal_dis(o)];
     },
     
-    /*
-      Text rendering based fingerprinting.
-      By rendering various fonts and taking note of device pixel ratio
-      we're able to build a fingerprint on the user.
-
-      On my M1 Macbook Air on Safari the fmh hash returns "4d624c99ce55b315c4f2eddf110ab32c60f386cf5ccf175f66d4b8ecaf332b09"
-      while my Windows machine returns "b89fb7541ffbbc3a0c9e37f0c9e6b56019c29c7a0c8644f8f587d8af18fc2426"
-    */
+    /**
+     * Text rendering based fingerprinting.     
+     *   By rendering various fonts and taking note of device pixel ratio
+     *   we're able to build a fingerprint on the user.
+     * 
+     *   On my M1 Macbook Air on Safari the fmh hash returns "4d624c99ce55b315c4f2eddf110ab32c60f386cf5ccf175f66d4b8ecaf332b09"
+     *   while my Windows machine returns "b89fb7541ffbbc3a0c9e37f0c9e6b56019c29c7a0c8644f8f587d8af18fc2426"
+     */
     fm: function() {
       var t = ["Monospace", "Wingdings 2", "ITC Bodoni 72 Bold", "Menlo", "Gill Sans MT", "Lucida Sans", "Bodoni 72", "Serif", "Shree Devanagari 714", "Microsoft Tai Le", "Nimbus Roman No 9 L", "Candara", "Press Start 2P", "Waseem"],
         a = document.createElement("span");
@@ -1264,21 +1279,21 @@ var _cf = _cf || [],
       bmak.fmz = "devicePixelRatio" in window && void 0 !== window.devicePixelRatio ? window.devicePixelRatio : -1;
     },
     
-    /*
-    WebGL based detections through the capturing of GPU and vendor
-    + the collection of hashed supported web extensions.
-
-    Original function:
-      wgl: function() {
-        try {
-          var t = document.createElement("canvas"),
-            a = t.getContext("webgl");
-          bmak.wv = "n", bmak.wr = "n", bmak.weh = "n", bmak.wl = 0, a && (bmak.wv = "b", bmak.wr = "b", bmak.weh = "b", a.getSupportedExtensions() && (bmak.weh = bmak.ats(bmak.mn_s(JSON.stringify(a.getSupportedExtensions().sort()))), bmak.wl = a.getSupportedExtensions().length, a.getSupportedExtensions().indexOf("WEBGL_debug_renderer_info") >= 0 && (bmak.wv = a.getParameter(a.getExtension("WEBGL_debug_renderer_info").UNMASKED_VENDOR_WEBGL), bmak.wr = a.getParameter(a.getExtension("WEBGL_debug_renderer_info").UNMASKED_RENDERER_WEBGL))));
-        } catch (t) {
-          bmak.wv = "e", bmak.wr = "e", bmak.weh = "e", bmak.wl = 0;
-        }
-      }
-    */
+    /**
+     * WebGL based detections through the capturing of GPU and vendor
+     * + the collection of hashed supported web extensions.
+     * 
+     * Original function:
+     *   wgl: function() {
+     *    try {
+     *       var t = document.createElement("canvas"),
+     *         a = t.getContext("webgl");
+     *       bmak.wv = "n", bmak.wr = "n", bmak.weh = "n", bmak.wl = 0, a && (bmak.wv = "b", bmak.wr = "b", bmak.weh = "b", a.getSupportedExtensions() && (bmak.weh = bmak.ats(bmak.mn_s(JSON.stringify(a.getSupportedExtensions().sort()))), bmak.wl = a.getSupportedExtensions().length, a.getSupportedExtensions().indexOf("WEBGL_debug_renderer_info") >= 0 && (bmak.wv = a.getParameter(a.getExtension("WEBGL_debug_renderer_info").UNMASKED_VENDOR_WEBGL), bmak.wr = a.getParameter(a.getExtension("WEBGL_debug_renderer_info").UNMASKED_RENDERER_WEBGL))));
+     *     } catch (t) {
+     *       bmak.wv = "e", bmak.wr = "e", bmak.weh = "e", bmak.wl = 0;
+     *     }
+     *   }
+     */
     wgl: function() {
       try {
         var t = document.createElement("canvas");
@@ -1317,24 +1332,24 @@ var _cf = _cf || [],
       }
     },
     
-    /*
-      Can be used to fingerprint and determine what device/browser
-      a user is using.
-
-      The voices provided in the Web Speech API is different
-      depending on the browser.
-
-      My Chrome 92 reports 67 voices while Safari reports 48.
-      The voices are also completely different with none of the
-      voiceURIs matching.
-
-      Each voice is turned into a string with the following format:
-      "voiceURI_lang" and the final string is SHA256 hashed and stored
-      in bmak.ssh.
-      
-      If no voices exist "0" is stored in bmak.ssh.
-      If speech synthesis is not available "n" is stored in bmak.ssh.
-    */
+    /**
+     * Can be used to fingerprint and determine what device/browser
+     * a user is using.
+     * 
+     * The voices provided in the Web Speech API is different
+     * depending on the browser.
+     * 
+     * My Chrome 92 reports 67 voices while Safari reports 48.
+     * The voices are also completely different with none of the
+     * voiceURIs matching.
+     * 
+     * Each voice is turned into a string with the following format:
+     * "voiceURI_lang" and the final string is SHA256 hashed and stored
+     * in bmak.ssh.
+     * 
+     * If no voices exist "0" is stored in bmak.ssh.
+     * If speech synthesis is not available "n" is stored in bmak.ssh.
+     */
     csh: function() {
       if (window.speechSynthesis) {
         var t = window.speechSynthesis.getVoices();
@@ -1347,55 +1362,55 @@ var _cf = _cf || [],
       } else bmak.ssh = "n";
     },
     
-    /*
-      Create a bit field checking for the existence of any
-      browser automation drivers
-
-      0:  window.__nightmare
-      1:  window.cdc_adoQpoasnfa76pfcZLmcfl_Array
-      2:  window.cdc_adoQpoasnfa76pfcZLmcfl_Promise
-      3:  window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol
-      4:  window.OSMJIF
-      5:  window._Selenium_IDE_Recorder
-      6:  window.__$webdriverAsyncExecutor
-      7:  window.__driver_evaluate
-      8:  window.__driver_unwrapped
-      9:  window.__fxdriver_evaluate
-      10: window.__fxdriver_unwrapped
-      11: window.__lastWatirAlert
-      12: window.__lastWatirConfirm
-      13: window.__lastWatirPrompt
-      14: window.__phantomas
-      15: window.__selenium_evaluate
-      16: window.__selenium_unwrapped
-      17: window.__webdriverFuncgeb
-      18: window.__webdriver__chr
-      19: window.__webdriver_evaluate
-      20: window.__webdriver_script_fn
-      21: window.__webdriver_script_func
-      22: window.__webdriver_script_function
-      23: window.__webdriver_unwrapped
-      24: window.awesomium
-      25: window.callSelenium
-      26: window.calledPhantom
-      27: window.calledSelenium
-      28: window.domAutomationController
-      29: window.watinExpressionError
-      30: window.watinExpressionResult
-      31: window.spynner_additional_js_loaded
-      32: document.$chrome_asyncScriptInfo
-      33: window.fmget_targets
-      34: window.geb
-
-
-      Running this function on my current machine on Chrome
-      returns the number 0.
-
-      Converting these numbers to binary allows you to see which properties
-      exist and don't in your browser.
-
-      (The first bit from the left specifies whether window.geb exists and the last bit is window.__nightmare)
-    */
+    	/**
+     * Create a bit field checking for the existence of any
+     * browser automation drivers
+     * 
+     * 0:  window.__nightmare        
+     * 1:  window.cdc_adoQpoasnfa76pfcZLmcfl_Array    
+     * 2:  window.cdc_adoQpoasnfa76pfcZLmcfl_Promise    
+     * 3:  window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol    
+     * 4:  window.OSMJIF    
+     * 5:  window._Selenium_IDE_Recorder    
+     * 6:  window.__$webdriverAsyncExecutor    
+     * 7:  window.__driver_evaluate    
+     * 8:  window.__driver_unwrapped    
+     * 9:  window.__fxdriver_evaluate    
+     * 10: window.__fxdriver_unwrapped    
+     * 11: window.__lastWatirAlert    
+     * 12: window.__lastWatirConfirm    
+     * 13: window.__lastWatirPrompt    
+     * 14: window.__phantomas    
+     * 15: window.__selenium_evaluate    
+     * 16: window.__selenium_unwrapped    
+     * 17: window.__webdriverFuncgeb    
+     * 18: window.__webdriver__chr    
+     * 19: window.__webdriver_evaluate    
+     * 20: window.__webdriver_script_fn    
+     * 21: window.__webdriver_script_func    
+     * 22: window.__webdriver_script_function    
+     * 23: window.__webdriver_unwrapped    
+     * 24: window.awesomium    
+     * 25: window.callSelenium    
+     * 26: window.calledPhantom    
+     * 27: window.calledSelenium    
+     * 28: window.domAutomationController    
+     * 29: window.watinExpressionError    
+     * 30: window.watinExpressionResult    
+     * 31: window.spynner_additional_js_loaded    
+     * 32: document.$chrome_asyncScriptInfo    
+     * 33: window.fmget_targets    
+     * 34: window.geb    
+     * 
+     * 
+     * Running this function on my current machine on Chrome
+     * returns the number 0.
+     * 
+     * Converting these numbers to binary allows you to see which properties
+     * exist and don't in your browser.
+     * 
+     * (The first bit from the left specifies whether window.geb exists and the last bit is window.__nightmare)
+     */
     hbs: function() {
       try {
         return Boolean(window.__nightmare) + (Boolean(window.cdc_adoQpoasnfa76pfcZLmcfl_Array) << 1) + (Boolean(window.cdc_adoQpoasnfa76pfcZLmcfl_Promise) << 2) + (Boolean(window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol) << 3) + (Boolean(window.OSMJIF) << 4) + (Boolean(window._Selenium_IDE_Recorder) << 5) + (Boolean(window.__$webdriverAsyncExecutor) << 6) + (Boolean(window.__driver_evaluate) << 7) + (Boolean(window.__driver_unwrapped) << 8) + (Boolean(window.__fxdriver_evaluate) << 9) + (Boolean(window.__fxdriver_unwrapped) << 10) + (Boolean(window.__lastWatirAlert) << 11) + (Boolean(window.__lastWatirConfirm) << 12) + (Boolean(window.__lastWatirPrompt) << 13) + (Boolean(window.__phantomas) << 14) + (Boolean(window.__selenium_evaluate) << 15) + (Boolean(window.__selenium_unwrapped) << 16) + (Boolean(window.__webdriverFuncgeb) << 17) + (Boolean(window.__webdriver__chr) << 18) + (Boolean(window.__webdriver_evaluate) << 19) + (Boolean(window.__webdriver_script_fn) << 20) + (Boolean(window.__webdriver_script_func) << 21) + (Boolean(window.__webdriver_script_function) << 22) + (Boolean(window.__webdriver_unwrapped) << 23) + (Boolean(window.awesomium) << 24) + (Boolean(window.callSelenium) << 25) + (Boolean(window.calledPhantom) << 26) + (Boolean(window.calledSelenium) << 27) + (Boolean(window.domAutomationController) << 28) + (Boolean(window.watinExpressionError) << 29) + (Boolean(window.watinExpressionResult) << 30) + (Boolean(window.spynner_additional_js_loaded) << 31) + (Boolean(document.$chrome_asyncScriptInfo) << 32) + (Boolean(window.fmget_targets) << 33) + (Boolean(window.geb) << 34);
@@ -1404,16 +1419,17 @@ var _cf = _cf || [],
       }
     },
     
-    /*
-      Checks if navigator.webdriver is true.
-      https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver
-
-      This property is true when in:
-      Chrome
-        The --enable-automation or the --headless flag or the --remote-debugging-port is used.
-      Firefox
-        The marionette.enabled preference or --marionette flag is passed.
-    */
+    /**
+     * Checks if navigator.webdriver is true.
+     * https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver
+     *
+     * This property is true when in:
+     * Chrome
+     *   The --enable-automation or the --headless flag or the --remote-debugging-port is used.
+     * Firefox
+     *   The marionette.enabled preference or --marionette flag is passed.
+     * @returns 
+     */
     gwd: function() {
       try {
         return navigator.webdriver ? navigator.webdriver : -1;
@@ -1422,12 +1438,12 @@ var _cf = _cf || [],
       }
     },
     
-    /*
-      Accumulate the ascii values of each character of 
-      "name" or "id" attribute
-      (uses name if it exists, id otherwise, returns -1 if none exists)
+    /**
+      * Accumulate the ascii values of each character of 
+      * "name" or "id" attribute
+      * (uses name if it exists, id otherwise, returns -1 if none exists)
 
-      if the parameter is null it will use document.activeElement
+      * if the parameter is null it will use document.activeElement
     */
     gf: function(t) {
       var a;

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -5,146 +5,200 @@ var _cf = _cf || [],
   /**
    * @namespace bmak
    * @version 1.7
-   * @property {number} ver                     - Akamai version, e.g: 1.7
-   * @property {number} ke_cnt_lmt              - Max keyboard event limit
-   * @property {number} mme_cnt_lmt             - Max mouse move event limit
-   * @property {number} mduce_cnt_lmt           - Max mouse down/up event limit
-   * @property {number} pme_cnt_lmt             - 
-   * @property {number} pduce_cnt_lmt           - Max pointer event limit
-   * @property {number} tme_cnt_lmt             - Touch move event limit
-   * @property {number} doe_cnt_lmt             - Device orientation event limit
-   * @property {number} dme_cnt_lmt             - Device motion event limit
-   * @property {number} vc_cnt_lmt              - Visibility change count limit
-   * @property {number} doa_throttle
-   * @property {number} dma_throttle
-   * @property {string} session_id
-   * @property {boolean | number} js_post
-   * @property {string} loc
-   * @property {string} cf_url
-   * @property {string} params_url
-   * @property {string} auth
-   * @property {string} api_public_key
-   * @property {number} aj_lmt_doact
-   * @property {number} aj_lmt_dmact
-   * @property {number} aj_lmt_tact
-   * @property {number} ce_js_post
-   * @property {number} init_time
-   * @property {string} informinfo
-   * @property {number} prevfid
-   * @property {number} fidcnt
-   * @property sensor_data
-   * @property ins
-   * @property cns
-   * @property {number} enGetLoc
-   * @property {number} enReadDocUrl
-   * @property {number} disFpCalOnTimeout
-   * @property {number} xagg
-   * @property {number} pen                     - Phantom https://phantomjs.org/ has been detected, check bmisc()
-   * @property {string} brow
-   * @property {string} browver
-   * @property {string} psub                    - Browser build number
-   * @property {string} lang                    - User's browser's preferred language
-   * @property {string} prod
-   * @property {number} plen
-   * @property {number} doadma_en
-   * @property sdfn
-   * @property {number} d2
-   * @property {number} d3
-   * @property {number} thr
-   * @property {string} cs
-   * @property {string} hn
-   * @property {number} z1
-   * @property {number} o9
-   * @property vc
-   * @property {number} y1
-   * @property {number} ta
-   * @property {number} tst
-   * @property {number} t_tst
-   * @property {string} ckie                    -  
-   * @property n_ck
-   * @property {number} ckurl
-   * @property bm
-   * @property {string} mr
-   * @property altFonts
-   * @property rst
-   * @property runFonts
-   * @property fsp
-   * @property firstLoad
-   * @property pstate
-   * @property {number} mn_mc_lmt
-   * @property {number} mn_state
-   * @property {number} mn_mc_indx
-   * @property {number} mn_sen
-   * @property {number} mn_tout
-   * @property {number} mn_stout
-   * @property {number} mn_ct
-   * @property {string} mn_cc
-   * @property {number} mn_cd
-   * @property mn_lc
-   * @property mn_ld
-   * @property {number} mn_lcl
-   * @property mn_al
-   * @property mn_il
-   * @property mn_tcl
-   * @property mn_r
-   * @property {number} mn_rt
-   * @property {number} mn_wt
-   * @property {string} mn_abck
-   * @property {string} mn_psn
-   * @property {string} mn_ts
-   * @property mn_lg
-   * @property {number} loap
-   * @property {number} dcs
    */
   bmak = { // Old declaration ` bmak && bmak.hasOwnProperty("ver") && bmak.hasOwnProperty("sed") ? bmak : ...`
+    /**
+     * Akamai version, e.g: 1.7
+     * @type {number}
+     */
     ver: 1.7,
+    /**
+     * Max keyboard event limit
+     * @type {number} ke_cnt_lmt
+     */
     ke_cnt_lmt: 150,
+    /**
+     * Max mouse move event limit
+     * @type {number}
+     */
     mme_cnt_lmt: 100,
+    /**
+     * Max mouse down/up event limit
+     * @type {number}
+     */
     mduce_cnt_lmt: 75,
+    /**
+     * @type {number}
+     */
     pme_cnt_lmt: 25,
+    /**
+     * Max pointer event limit
+     * @type {number}
+     */
     pduce_cnt_lmt: 25,
+    /**
+     * Touch move event limit
+     * @type {number}
+     */
     tme_cnt_lmt: 25,
     tduce_cnt_lmt: 25,
+    /**
+     * Device orientation event limit
+     * @type {number}
+     */
     doe_cnt_lmt: 10,
+    /**
+     * Device motion event limit
+     * @type {number}
+     */
     dme_cnt_lmt: 10,
+    /**
+     * Visibility change count limit
+     * @type {number}
+     */
     vc_cnt_lmt: 100,
+    /**
+     * @type {number}
+     */
     doa_throttle: 0, 
+    /**
+     * @type {number}
+     */
     dma_throttle: 0,
+    /**
+     * @type {string}
+     */
     session_id: "default_session",
     js_post: !1,
+    /**
+     * @type {string}
+     */
     loc: "",
+    /**
+     * @type {string}
+     */
     cf_url: "https:" === document.location.protocol ? "https://" : "http://",
+    /**
+     * @type {string}
+     */
     params_url: ("https:" === document.location.protocol ? "https://" : "http://") + document.location.hostname + "/get_params",
+    /**
+     * @type {string}
+     */
     auth: "",
+    /**
+     * @type {string}
+     */
     api_public_key: "afSbep8yjnZUjq3aL010jO15Sawj2VZfdYK8uY90uxq",
+    /**
+     * @type {number}
+     */
     aj_lmt_doact: 1,
+    /**
+     * @type {number}
+     */
     aj_lmt_dmact: 1,
+    /**
+     * @type {number}
+     */
     aj_lmt_tact: 1,
+    /**
+     * @type {number}
+     */
     ce_js_post: 0,
+    /**
+     * @type {number}
+     */
     init_time: 0,
+    /**
+     * @type {string}
+     */
     informinfo: "",
+    /**
+     * @type {number}
+     */
     prevfid: -1,
+    /**
+     * @type {number}
+     */
     fidcnt: 0,
+    /**
+     * @type {number}
+     */
     sensor_data: 0,
     ins: null,
     cns: null,
+    /**
+     * @type {number}
+     */
     enGetLoc: 0,
+    /**
+     * @type {number}
+     */
     enReadDocUrl: 1,
+    /**
+     * @type {number}
+     */
     disFpCalOnTimeout: 0,
+    /**
+     * @type {number}
+     */
     xagg: -1,
+    /**
+     * Phantom https://phantomjs.org/ has been detected, check bmisc()
+     * @type {number}
+     */
     pen: -1,
+    /**
+     * @type {string}
+     */
     brow: "",
+    /**
+     * @type {string}
+     */
     browver: "",
+    /**
+     * Browser build number
+     * @type {string}
+     */
     psub: "-",
+    /**
+     * User's browser's preferred language
+     * @type {string}
+     */
     lang: "-",
+    /**
+     * @type {string}
+     */
     prod: "-",
+    /**
+     * @type {number}
+     */
     plen: -1,
+    /**
+     * @type {number}
+     */
     doadma_en: 0,
     sdfn: [],
+    /**
+     * @type {number}
+     */
     d2: 0,
+    /**
+     * @type {number}
+     */
     d3: 0,
+    /**
+     * @type {number}
+     */
     thr: 0,
+    /**
+     * @type {string}
+     */
     cs: "0a46G5m17Vrp4o4c",
+    /**
+     * @type {string}
+     */
     hn: "unk",
     z1: 0,
     o9: 0,
@@ -153,10 +207,25 @@ var _cf = _cf || [],
     ta: 0,
     tst: -1,
     t_tst: 0,
+    /**
+     * @type {string}
+     */
     ckie: "_abck",
+    /**
+     * @type {string}
+     */
     n_ck: "0",
+    /**
+     * @type {number}
+     */
     ckurl: 0,
+    /**
+     * @type {number}
+     */
     bm: !1,
+    /**
+     * @type {string}
+     */
     mr: "-1",
     altFonts: !1,
     rst: !1,
@@ -164,13 +233,37 @@ var _cf = _cf || [],
     fsp: !1,
     firstLoad: !0,
     pstate: !1,
+    /**
+     * @type {number}
+     */
     mn_mc_lmt: 10,
+    /**
+     * @type {number}
+     */
     mn_state: 0,
+    /**
+     * @type {number}
+     */
     mn_mc_indx: 0,
+    /**
+     * @type {number}
+     */
     mn_sen: 0,
+    /**
+     * @type {number}
+     */
     mn_tout: 100,
+    /**
+     * @type {number}
+     */
     mn_stout: 1e3,
+    /**
+     * @type {number}
+     */
     mn_ct: 1,
+    /**
+     * @type {string}
+     */
     mn_cc: "",
     mn_cd: 1e4,
     mn_lc: [],
@@ -182,8 +275,17 @@ var _cf = _cf || [],
     mn_r: [],
     mn_rt: 0,
     mn_wt: 0,
+    /**
+     * @type {string}
+     */
     mn_abck: "",
+    /**
+     * @type {string}
+     */
     mn_psn: "",
+    /**
+     * @type {string}
+     */
     mn_ts: "",
     mn_lg: [],
     loap: 1,
@@ -405,7 +507,7 @@ var _cf = _cf || [],
          */
         k = d + "";
       
-        // ${userAgent},uaend,${functionsInBrowser},${buildNumber},${language},
+        // ${userAgent},uaend,${functionsInBrowser},${buildNumber},${language},Gecko,${legacyPlugins}
       return k = k.slice(0, 11) + s, bmak.gbrv(), bmak.get_browser(), bmak.bc(), bmak.bmisc(), t + ",uaend," + bmak.xagg + "," + bmak.psub + "," + bmak.lang + "," + bmak.prod + "," + bmak.plen + "," + bmak.pen + "," + bmak.wen + "," + bmak.den + "," + bmak.z1 + "," + bmak.d3 + "," + n + "," + o + "," + m + "," + r + "," + c + "," + i + "," + b + "," + bmak.bd() + "," + a + "," + k + "," + e + "," + bmak.brv + ",loc:" + bmak.loc;
     },
     
@@ -438,20 +540,24 @@ var _cf = _cf || [],
         bmak.lang = navigator.language
       }
 
-      // All browsers return "Gecko" for compatibility reasons.
       if (navigator.product) {
+        /**
+         * All browsers return "Gecko" for compatibility reasons.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/product
+         */
         bmak.prod = navigator.product
       }
 
-      // Legacy browser plugins. Not to be confused with extensions.
-      // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/plugins
       if (navigator.plugins !== undefined) {
+        /**
+         * Legacy browser plugins. Not to be confused with extensions.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/plugins
+         */
         bmak.plen = navigator.plugins.length;
       } else {
         bmak.plen = -1;
       }
     },
-    
     
     /**
      * 

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -147,30 +147,39 @@ var _cf = _cf || [],
     },
     
     /**
-     * Returns the Date in a Unix time format https://en.wikipedia.org/wiki/Unix_time
+     * Returns the Date in a Unix time format 
+     * https://en.wikipedia.org/wiki/Unix_time
      * @returns {number} Unix time (timestamp), e.g: 1631080958
      */
     get_cf_date: function() {
       return Date.now ? Date.now() : +new Date();
     },
-    
+
     sd_debug: function(t) {
       if (!bmak.js_post) {
         var a = t;
         "string" == typeof _sd_trace ? _sd_trace += a : _sd_trace = a;
       }
     },
-    // parseInt
+    
+    /**
+     * Convert a string to a number
+     * @param {string} t string to convert to number, e.g: "23"
+     * @returns string converted to a number
+     */
     pi: function(t) {
       return parseInt(t);
     },
     
-    /*
-      Return User Agent
-    */
+    /**
+     * Returns the User-Agent of the current browser window 
+     * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+     * @returns {string} a User-Agent string stripped from every \\|" string, e.g: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15
+     */
     uar: function() {
       return window.navigator.userAgent.replace(/\\|"/g, "");
     },
+
     gd: function() {
       var t = bmak.uar(), // user agent
         a = "" + bmak.ab(t), // Accumulate all char codes in the user agent and return number

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -3,7 +3,8 @@
 */
 var _cf = _cf || [],
   /**
-   * @namespace
+   * @namespace bmak
+   * @version 1.7
    * @property {number} ver                     - Akamai version, e.g: 1.7
    * @property {number} ke_cnt_lmt              - Max keyboard event limit
    * @property {number} mme_cnt_lmt             - Max mouse move event limit
@@ -41,8 +42,8 @@ var _cf = _cf || [],
    * @property {number} pen                     - Phantom https://phantomjs.org/ has been detected, check bmisc()
    * @property {string} brow
    * @property {string} browver
-   * @property {string} psub
-   * @property {string} lang
+   * @property {string} psub                    - Browser build number
+   * @property {string} lang                    - User's browser's preferred language
    * @property {string} prod
    * @property {number} plen
    * @property {number} doadma_en
@@ -95,7 +96,7 @@ var _cf = _cf || [],
    * @property {number} loap
    * @property {number} dcs
    */
-  bmak = bmak && bmak.hasOwnProperty("ver") && bmak.hasOwnProperty("sed") ? bmak : {
+  bmak = { // Old declaration ` bmak && bmak.hasOwnProperty("ver") && bmak.hasOwnProperty("sed") ? bmak : ...`
     ver: 1.7,
     ke_cnt_lmt: 150,
     mme_cnt_lmt: 100,
@@ -267,46 +268,92 @@ var _cf = _cf || [],
     /**
      * Returns the User-Agent of the current browser window 
      * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+     * @method uar
+     * @memberof bmak
      * @returns {string} a User-Agent string stripped from every \\|" string, e.g: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15
      */
     uar: function() {
       return window.navigator.userAgent.replace(/\\|"/g, "");
     },
 
+    /**
+     * Get some window properties values
+     * Difference between inner/outer/classic sizes https://stackoverflow.com/a/17845094/12440368
+     * @method gd
+     * @memberof bmak
+     * @namespace bmak.gd
+     * @returns 
+     */
     gd: function() {
-      var t = bmak.uar(), // user agent
-        a = "" + bmak.ab(t), // Accumulate all char codes in the user agent and return number
-        e = bmak.start_ts / 2, // Start time / 2
+      /**
+       * Store User-Agent
+       * @type {string}
+       */
+      var t = bmak.uar(),
+        /**
+         * Accumulate all char codes in the user agent and store it in {a}
+         * @type {string}
+         */
+        a = "" + bmak.ab(t),
+        /**
+         * Current timestamp divided by 2
+         * @type {number}
+         */
+        e = bmak.start_ts / 2, 
+        /**
+         * Store the available width
+         * @type {number}
+         */
         n = -1,
+        /**
+         * Store the available height
+         * @type {number}
+         */
         o = -1,
+        /**
+         * Store the screen width
+         * @type {number}
+         */
         m = -1,
+        /**
+         * Store the screen height
+         * @type {number}
+         */
         r = -1,
+        /**
+         * Store the window inner height
+         * @type {number}
+         */
         i = -1,
+        /**
+         * Store the window inner width
+         * @type {number}
+         */
         c = -1,
+        /**
+         * Store the window outer width
+         * @type {number}
+         */
         b = -1;
 
-      // Gets the available width
       try {
         n = window.screen ? window.screen.availWidth : -1;
       } catch (t) {
         n = -1;
       }
 
-      // Gets the available height
       try {
         o = window.screen ? window.screen.availHeight : -1;
       } catch (t) {
         o = -1;
       }
 
-      // Get screen width
       try {
         m = window.screen ? window.screen.width : -1;
       } catch (t) {
         m = -1;
       }
 
-      // Get screen height
       try {
         r = window.screen ? window.screen.height : -1;
       } catch (t) {
@@ -332,23 +379,33 @@ var _cf = _cf || [],
       }
 
       
-      /*
-        parseInt(start timestamp / 4064256)
-        
-        Creates a rough estimate of the hour identifier for start timestamp(bmak.start_ts).
-
-        "dividing by 4064256 and parsing as an int gives you a number that should be constant for all valid sensor datas, 
-        but changes every ~hour (4064256ms is 67 minutes 44.256 seconds, 
-        not sure why this wouldnt be exactly 60 min but close enough i guess)"
-        - xssc
-
-        see: https://github.com/char/bpre/issues/1#issuecomment-914575546
-      */
-      bmak.z1 = bmak.pi(bmak.start_ts / (bmak.y1 * bmak.y1));
-      var d = Math.random(), // number between 0 and 1 
-        s = bmak.pi(1e3 * d / 2), // 0 < s < 499 because: 1000 * (nb between 0-1) / 2
-        k = d + ""; // d.toString()
+      /**
+       * @description Creates a rough estimate of the hour identifier for start timestamp(bmak.start_ts).
+       * "dividing by 4064256 and parsing as an int gives you a number that should be constant for all valid sensor datas, 
+       * but changes every ~hour (4064256ms is 67 minutes 44.256 seconds, 
+       * not sure why this wouldnt be exactly 60 min but close enough i guess)"
+       * @author xssc <https://github.com/xssc>
+       * see: https://github.com/char/bpre/issues/1#issuecomment-914575546
+       */
+      bmak.z1 = bmak.pi(bmak.start_ts / (bmak.y1 * bmak.y1)); // parseInt(start timestamp / 4064256) 
+      /**
+       * Number between 0 and 1
+       * @type {number}
+       */
+      var d = Math.random(),
+        /**
+         * Number between 0 and 499
+         * 0 < s < 499 because: 1000 * (nb between 0-1) / 2
+         * @type {number}
+         */
+        s = bmak.pi(1e3 * d / 2),
+        /**
+         * A string representing a number between 0 and 1
+         * @type {string}
+         */
+        k = d + "";
       
+        // ${userAgent},uaend,${functionsInBrowser},${buildNumber},${language},
       return k = k.slice(0, 11) + s, bmak.gbrv(), bmak.get_browser(), bmak.bc(), bmak.bmisc(), t + ",uaend," + bmak.xagg + "," + bmak.psub + "," + bmak.lang + "," + bmak.prod + "," + bmak.plen + "," + bmak.pen + "," + bmak.wen + "," + bmak.den + "," + bmak.z1 + "," + bmak.d3 + "," + n + "," + o + "," + m + "," + r + "," + c + "," + i + "," + b + "," + bmak.bd() + "," + a + "," + k + "," + e + "," + bmak.brv + ",loc:" + bmak.loc;
     },
     
@@ -360,16 +417,24 @@ var _cf = _cf || [],
       }
     */
     get_browser: function() {
-      // Safari and Chrome will always return "20030107"
-      // Firefox returns "20100101" and this doesn't exist on IE
       if (navigator.productSub) {
+        /**
+       * Browser build number
+       * Safari and Chrome will always return "20030107"
+       * Firefox returns "20100101" and this doesn't exist on IE
+       * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/productSub
+       */
         bmak.psub = navigator.productSub
       }
 
-      // User's browser's preferred language. This can be represented
-      // differently depending on the browser. For example,
-      // English is stylized as en-US in Chrome but en-us in Safari
       if(navigator.language) {
+        /**
+         * User's browser's preferred language. 
+         * This can be represented
+         * differently depending on the browser. For example,
+         * English is stylized as en-US in Chrome but en-us in Safari
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
+         */
         bmak.lang = navigator.language
       }
 

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -7,6 +7,7 @@ var _cf = _cf || [],
    * @version 1.7
    * @property {string} wen                     - Webdriver activated
    * @property {string} den                     - Headless Chrome
+   * @property {number} brv                     - Brave
    */
   bmak = { // Old declaration ` bmak && bmak.hasOwnProperty("ver") && bmak.hasOwnProperty("sed") ? bmak : ...`
     /**
@@ -526,12 +527,20 @@ var _cf = _cf || [],
     
     /*
 
-    Original Function:
-      get_browser: function() {
-        navigator.productSub && (bmak.psub = navigator.productSub), navigator.language && (bmak.lang = navigator.language), navigator.product && (bmak.prod = navigator.product), bmak.plen = void 0 !== navigator.plugins ? navigator.plugins.length : -1;
-      }
+    
     */
+    /**
+     * Get browser identity
+     * @see {@link bmak.psub} {@link bmak.lang} {@link bmak.prod} {@link bmak.plen}
+     */
     get_browser: function() {
+      /**
+       * Original Function:
+       * get_browser: function() {
+       *   navigator.productSub && (bmak.psub = navigator.productSub), navigator.language && (bmak.lang = navigator.language), navigator.product && (bmak.prod = navigator.product), bmak.plen = void 0 !== navigator.plugins ? navigator.plugins.length : -1;
+       * }
+       */
+
       if (navigator.productSub) {
         /**
        * Browser build number
@@ -578,11 +587,9 @@ var _cf = _cf || [],
      * The navigator.brave property only exists on
      * Brave browsers.
      *
-     * Brave is a Chromium basedprivacy browser that 
-     * blocks trackers and enables some privacy settings.
-     *
      * They can potentially use this check to loosen
      * fingerprinting requirements if Brave is detected.
+     * @see https://en.wikipedia.org/wiki/Brave_(web_browser)
      */
     gbrv: function() {
       navigator.brave && navigator.brave.isBrave().then(function(t) {
@@ -592,63 +599,104 @@ var _cf = _cf || [],
       });
     },
     
-    /*
-      Function crafts a bit field that determines whether
-      various window functions exist.
+    /**
+     * Function crafts a bit field that determines whether
+     * various window functions exist.
+     * 
+     *  0:  window.addEventListener     
+     *  1:  window.XMLHttpRequest     
+     *  2:  window.XDomainRequest     
+     *  3:  window.emit     
+     *  4:  window.DeviceOrientationEvent     
+     *  5:  window.DeviceMotionEvent     
+     *  6:  window.TouchEvent     
+     *  7:  window.spawn     
+     *  8:  window.innerWidth     
+     *  9:  window.outerWidth     
+     *  10: window.chrome     
+     *  11: Function.prototype.bind     
+     *  12: window.Buffer     
+     *  13: window.PointerEvent     
+     * 
+     *  Running this in my Chrome 91 returns 12147 while Safari returns 11011.     
+     *  Converting these to binary allow us to see which properties do and don't exist on these browsers.
+     * 
+     *  The 4th bit from the left represents window.chrome and we can see      
+     *  Chrome returns true (1) while Safari is false (0)
 
-      0:  window.addEventListener
-      1:  window.XMLHttpRequest
-      2:  window.XDomainRequest
-      3:  window.emit
-      4:  window.DeviceOrientationEvent
-      5:  window.DeviceMotionEvent
-      6:  window.TouchEvent
-      7:  window.spawn
-      8:  window.innerWidth
-      9:  window.outerWidth
-      10: window.chrome
-      11: Function.prototype.bind
-      12: window.Buffer
-      13: window.PointerEvent
-
-      Running this in my Chrome 91 returns 12147 whiile Safari returns 11011.
-      Converting these to binary allow us to see which properties do and don't exist on these browsers.
-
-      The 4th bit from the left represents window.chrome and we can see 
-      Chrome returns true (1) while Safari is false (0)
-
-      12147: 1 0 1 1 1 1 0 1 1 1 0 0 1 1
-      11011: 1 0 1 0 1 1 0 0 0 0 0 0 1 1
-
-    */
+     *  12147: 1 0 1 1 1 1 0 1 1 1 0 0 1 1     
+     *  11011: 1 0 1 0 1 1 0 0 0 0 0 0 1 1
+     */
     bc: function() {
+      /**
+       * addEventListener available
+       */
       var t = window.addEventListener ? 1 : 0,
+        /**
+         * XMLHttpRequest available
+         */
         a = window.XMLHttpRequest ? 1 : 0,
-        // Only exists for Internet Explorer
+        /**
+         * XDomainRequest available    
+         * Only exists for Internet Explorer 
+         */
         e = window.XDomainRequest ? 1 : 0,
+        /**
+         * emit available    
+         */
         n = window.emit ? 1 : 0,
-        // Not supported on Safari and IE
+        /**
+         * DeviceOrientationEvent available    
+         * Not supported on Safari and IE
+         */
         o = window.DeviceOrientationEvent ? 1 : 0,
-        // Not supported on Safari and IE
+        /**
+         * DeviceMotionEvent available    
+         * Not supported on Safari and IE
+         */
         m = window.DeviceMotionEvent ? 1 : 0,
-        // Not supported on Safari and IE
+        /**
+         * TouchEvent available    
+         * Not supported on Safari and IE
+         */
         r = window.TouchEvent ? 1 : 0,
-        // Doesnt exist in browsers. Maybe used as a check to see if its running in a Node environment.
+        /**
+         * spawn available    
+         * Doesnt exist in browsers. Maybe used as a check to see if its running in a Node environment.
+         */
         i = window.spawn ? 1 : 0,
-        // Check to see if running in Chrome
+        /**
+         * chrome available    
+         * Check to see if running in Chrome
+         */
         c = window.chrome ? 1 : 0,
+        /**
+         * Function.prototype.bind available    
+         */
         b = Function.prototype.bind ? 1 : 0,
-        // Doesnt exist in browsers. Maybe used as a check to see if its running in a Node environment (global.Buffer).
+        /**
+         * Buffer available    
+         * Doesnt exist in browsers. Maybe used as a check to see if its running in a Node environment (global.Buffer).
+         */
         d = window.Buffer ? 1 : 0,
+        /**
+         * PointerEvent available    
+         */
         s = window.PointerEvent ? 1 : 0;
 
       try {
+        /**
+         * Window Inner Width    
+         */
         var k = window.innerWidth ? 1 : 0;
       } catch (t) {
         var k = 0;
       }
 
       try {
+        /**
+         * Window Outer Width    
+         */
         var l = window.outerWidth ? 1 : 0;
       } catch (t) {
         var l = 0;
@@ -657,10 +705,10 @@ var _cf = _cf || [],
       bmak.xagg = t + (a << 1) + (e << 2) + (n << 3) + (o << 4) + (m << 5) + (r << 6) + (i << 7) + (k << 8) + (l << 9) + (c << 10) + (b << 11) + (d << 12) + (s << 13);
     },
     
-    /*
-      Check for browser driver automation:
-      https://www.selenium.dev/selenium
-    */
+    /**
+     * Check for browser driver automation
+     * @see https://stackoverflow.com/a/24471222
+     */
     bmisc: function() {
       // _phantom https://phantomjs.org/
       bmak.pen = window._phantom ? 1 : 0;
@@ -676,35 +724,68 @@ var _cf = _cf || [],
       // Headless chrome property
       bmak.den = window.domAutomation ? 1 : 0;
     },
+
+    /**
+     * Functions check for various Window and Navigator properties
+     * @returns {string} Every properties separated by a comma (,)
+     */
     bd: function() {
+      /**
+       * The array that will serve as the return string
+       */
       var t = [],
-      // Check for callback function for phantomJS (https://phantomjs.org/api/webpage/handler/on-callback.html)
+      /**
+       * Has callback function for phantomJS (https://phantomjs.org/api/webpage/handler/on-callback.html)
+       */
       a = window.callPhantom ? 1 : 0;
       t.push(",cpen:" + a);
       var e = 0;
-      // "The ActiveXObject object is used to create instances of OLE Automation objects in Internet Explorer on Windows operating systems."
-      // http://help.dottoro.com/ljiujjib.php#:~:text=The%20ActiveXObject%20object%20is%20used,to%20allow%20communication%20with%20them.
+      /**
+       * "The ActiveXObject object is used to create instances of OLE Automation objects in Internet Explorer on Windows operating systems."
+       * @see http://help.dottoro.com/ljiujjib.php#:~:text=The%20ActiveXObject%20object%20is%20used,to%20allow%20communication%20with%20them
+       */
       window.ActiveXObject && "ActiveXObject" in window && (e = 1), t.push("i1:" + e);
-      // Property only exists on IE. Prob an IE check 
+      /**
+       * Property only exists on IE. Prob an IE check
+       */ 
       var n = "number" == typeof document.documentMode ? 1 : 0;
       t.push("dm:" + n);
-      // Chrome check
+      /**
+       * Chrome check
+       */
       var o = window.chrome && window.chrome.webstore ? 1 : 0;
       t.push("cwen:" + o);
-      // Returns the online status of the browser. The property returns a boolean value, with true meaning online and false meaning offline
+      /**
+       * Returns the online status of the browser. The property returns a boolean value, with true meaning online and false meaning offline
+       */
       var m = navigator.onLine ? 1 : 0;
       t.push("non:" + m);
-      // Opera browser check
+      /**
+       * Opera browser check
+       */
       var r = window.opera ? 1 : 0;
       t.push("opc:" + r);
-      // Firefox check. InstallTrigger only exists on firefox and typeof InstallTrigger will return "object" on firefox based browsers. "undefined" otherwise
+      /**
+       * Firefox check. InstallTrigger only exists on firefox and typeof InstallTrigger will return "object" on firefox based browsers. "undefined" otherwise
+       */
       var i = "undefined" != typeof InstallTrigger ? 1 : 0;
       t.push("fc:" + i);
-      // Early safari check (https://stackoverflow.com/questions/15470777/what-does-this-statement-object-prototype-do)
+      /**
+       * Early safari check
+       * @see https://stackoverflow.com/questions/15470777/what-does-this-statement-object-prototype-do
+       */
       var c = window.HTMLElement && Object.prototype.toString.call(window.HTMLElement).indexOf("Constructor") > 0 ? 1 : 0;
       t.push("sc:" + c);
+      /**
+       * WebRTC check
+       * @see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection
+       */
       var b = "function" == typeof window.RTCPeerConnection || "function" == typeof window.mozRTCPeerConnection || "function" == typeof window.webkitRTCPeerConnection ? 1 : 0;
       t.push("wrc:" + b);
+      /**
+       * Firefox check as it's only available in Firefox.
+       * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/mozInnerScreenY
+       */
       var d = "mozInnerScreenY" in window ? window.mozInnerScreenY : 0;
       t.push("isc:" + d);
       
@@ -721,12 +802,28 @@ var _cf = _cf || [],
         see: https://github.com/char/bpre/issues/1#issuecomment-914575546
       */
       bmak.d2 = bmak.pi(bmak.z1 / 23);
+      /**
+       * Mobile check, only available in Chromium and Firefox
+       * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate
+       */
       var s = "function" == typeof navigator.vibrate ? 1 : 0;
       t.push("vib:" + s);
+      /**
+      * Mobile check, only available in Chromium and Opera
+      * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getBattery
+      */
       var k = "function" == typeof navigator.getBattery ? 1 : 0;
       t.push("bat:" + k);
+      /**
+       * JS check, some browsers don't support this function
+       * @see https://caniuse.com/?search=forEach
+       */
       var l = Array.prototype.forEach ? 0 : 1;
       t.push("x11:" + l);
+      /**
+       * JS check, some browsers don't support this function
+       * @see https://caniuse.com/?search=FileReader
+       */
       var u = "FileReader" in window ? 1 : 0;
       return t.push("x12:" + u), t.join(",");
     },

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -38,7 +38,7 @@ var _cf = _cf || [],
    * @property {number} enReadDocUrl
    * @property {number} disFpCalOnTimeout
    * @property {number} xagg
-   * @property {number} pen
+   * @property {number} pen                     - Phantom https://phantomjs.org/ has been detected, check bmisc()
    * @property {string} brow
    * @property {string} browver
    * @property {string} psub
@@ -345,9 +345,10 @@ var _cf = _cf || [],
         see: https://github.com/char/bpre/issues/1#issuecomment-914575546
       */
       bmak.z1 = bmak.pi(bmak.start_ts / (bmak.y1 * bmak.y1));
-      var d = Math.random(),
-        s = bmak.pi(1e3 * d / 2),
-        k = d + "";
+      var d = Math.random(), // number between 0 and 1 
+        s = bmak.pi(1e3 * d / 2), // 0 < s < 499 because: 1000 * (nb between 0-1) / 2
+        k = d + ""; // d.toString()
+      
       return k = k.slice(0, 11) + s, bmak.gbrv(), bmak.get_browser(), bmak.bc(), bmak.bmisc(), t + ",uaend," + bmak.xagg + "," + bmak.psub + "," + bmak.lang + "," + bmak.prod + "," + bmak.plen + "," + bmak.pen + "," + bmak.wen + "," + bmak.den + "," + bmak.z1 + "," + bmak.d3 + "," + n + "," + o + "," + m + "," + r + "," + c + "," + i + "," + b + "," + bmak.bd() + "," + a + "," + k + "," + e + "," + bmak.brv + ",loc:" + bmak.loc;
     },
     

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -1489,13 +1489,13 @@ var _cf = _cf || [],
       return 1 == (null == e ? -1 : bmak.get_type(e)) && bmak.fidcnt > 12 && -2 == t ? 1 : 0;
     },
     
-    /*
-      Key event function
-      Gets called on 
-      "keydown", "onkeydown", (a = 1)
-      "keyup", "onkeyup", (a = 2)
-      "keypress", "onkeypress" (a = 3)
-    */
+    /**
+     * Key event function
+     * Gets called on 
+     * "keydown", "onkeydown", (a = 1)
+     * "keyup", "onkeyup", (a = 2)
+     * "keypress", "onkeypress" (a = 3)
+     */
     cka: function(t, a) {
       try {
         var e = t || window.event,
@@ -1525,14 +1525,14 @@ var _cf = _cf || [],
       } catch (t) {}
     },
     
-    /*
-      Touch events function
-      Get called on:
-      "touchmove" (a = 1)
-      "touchstart" (a = 2)
-      "touchend" (a = 3)
-      "touchcancel" (a = 4)
-    */
+    /**
+     * Touch events function
+     * Get called on:
+     * "touchmove" (a = 1)
+     * "touchstart" (a = 2)
+     * "touchend" (a = 3)
+     * "touchcancel" (a = 4)
+     */
     cta: function(t, a) {
       try {
         if (1 == a && bmak.tme_cnt < bmak.tme_cnt_lmt || 1 != a && bmak.tduce_cnt < bmak.tduce_cnt_lmt) {
@@ -1549,14 +1549,15 @@ var _cf = _cf || [],
       } catch (t) {}
     },
     
-    /*
-      Parse the parameter as a float and only
-      return the float with a precision of 2
-      decimal spaces.
-
-      Return -1 if it can't be properly parsed
-      as a float.
-    */
+    /**
+     * Parse the parameter as a float and only
+     * return the float with a precision of 2
+     * decimal spaces.
+     *
+     * Return -1 if it can't be properly parsed
+     * as a float.
+     * @returns {number}
+     */
     getFloatVal: function(t) {
       try {
         if (-1 != bmak.chknull(t) && !isNaN(t)) {
@@ -1567,6 +1568,7 @@ var _cf = _cf || [],
 
       return -1;
     },
+
     cdoa: function(t) {
       try {
         if (bmak.doe_cnt < bmak.doe_cnt_lmt && bmak.doa_throttle < 2 && t) {
@@ -1581,6 +1583,7 @@ var _cf = _cf || [],
         bmak.js_post && bmak.doe_cnt > 1 && bmak.aj_indx_doact < bmak.aj_lmt_doact && (bmak.aj_type = 6, bmak.bpd(), bmak.pd(!0), bmak.ce_js_post = 1, bmak.aj_indx_doact++), bmak.doa_throttle++;
       } catch (t) {}
     },
+
     cdma: function(t) {
       try {
         if (bmak.dme_cnt < bmak.dme_cnt_lmt && bmak.dma_throttle < 2 && t) {
@@ -1605,22 +1608,26 @@ var _cf = _cf || [],
       } catch (t) {}
     },
     
-    /*
-      Get type of HTML input element
-      return 0 for: "text", "search", "url", "email", "tel", "number"
-      return 1 for: "password"
-      return 2 for: anything else
-    */
+    /**
+     * Get type of HTML input element    
+     * return 0 for: "text", "search", "url", "email", "tel", "number"    
+     * return 1 for: "password"    
+     * return 2 for: anything else    
+     * @returns {number}
+     */
     get_type: function(t) {
       return t = t.toLowerCase(), "text" == t || "search" == t || "url" == t || "email" == t || "tel" == t || "number" == t ? 0 : "password" == t ? 1 : 2;
     },
     
-    /*
-      Return -1 if null otherwise return parameter
-    */
+    /**
+     * Return -1 if null otherwise return parameter
+     * @param {any} t 
+     * @returns {number|any}
+     */
     chknull: function(t) {
       return null == t ? -1 : t;
     },
+
     getforminfo: function() {
       for (var t = "", a = "", e = document.getElementsByTagName("input"), n = -1, o = 0; o < e.length; o++) {
         var m = e[o],
@@ -1642,67 +1649,94 @@ var _cf = _cf || [],
       return null == bmak.ins && (bmak.ins = a), bmak.cns = a, t;
     },
     
-    /*
-      Adds event listeners for device orientation & device motion
-    */
+    /**
+     * Adds event listeners for device orientation & device motion
+     */
     startdoadma: function() {
       0 == bmak.doadma_en && window.addEventListener && (window.addEventListener("deviceorientation", bmak.cdoa, !0), window.addEventListener("devicemotion", bmak.cdma, !0), bmak.doadma_en = 1), bmak.doa_throttle = 0, bmak.dma_throttle = 0;
     },
     updatet: function() {
       return bmak.get_cf_date() - bmak.start_ts;
     },
-    // "touchmove" event
-    htm: function(t) {
+    /**
+     * "touchmove" event
+     */
+     htm: function(t) {
       bmak.cta(t, 1);
     },
-    // "touchstart" event
+    /**
+     * "touchstart" event
+     */
     hts: function(t) {
       bmak.cta(t, 2);
     },
-    // "touchend" event
+    /**
+     * "touchend" event
+     */
     hte: function(t) {
       bmak.cta(t, 3);
     },
-    // "touchcancel" event
+    /**
+     * "touchcancel" event
+     */
     htc: function(t) {
       bmak.cta(t, 4);
     },
-    // "mousemove" event
+    /**
+     * "mousemove" event
+     */
     hmm: function(t) {
       bmak.cma(t, 1);
     },
-    // "click" event
+    /**
+     * "click" event
+     */
     hc: function(t) {
       bmak.cma(t, 2);
     },
-    // "mousedown" event
+    /**
+     * "mousedown" event
+     */
     hmd: function(t) {
       bmak.cma(t, 3);
     },
-    // "mouseup" event
+    /**
+     * "mouseup" event
+     */
     hmu: function(t) {
       bmak.cma(t, 4);
     },
-    // "pointerdown" event
+    /**
+     * "pointerdown" event
+     */
     hpd: function(t) {
       bmak.cpa(t, 3);
     },
-    // "pointerup" event
+    /**
+     * "pointerup" event
+     */
     hpu: function(t) {
       bmak.cpa(t, 4);
     },
-    // "keydown" event
+    /**
+     * "keydown" event
+     */
     hkd: function(t) {
       bmak.cka(t, 1);
     },
-    // "keyup" event
+    /**
+     * "keyup" event
+     */
     hku: function(t) {
       bmak.cka(t, 2);
     },
-    // "keypress" event
+    /**
+     * "keypress" event
+     */
     hkp: function(t) {
       bmak.cka(t, 3);
     },
+
     form_submit: function() {
       try {
         if (bmak.bpd(), 0 == bmak.sdfn.length) {
@@ -1718,17 +1752,18 @@ var _cf = _cf || [],
       return bmak.bpd(), bmak.ir(), bmak.sensor_data;
     },
     
-    /*
-      Get the document URL and remove escape / quotation mark if exists.
-      Return empty string if bmak.enReadDocUrl is false
-    */
+    /**
+     * Get the document URL and remove escape / quotation mark if exists.
+     * @returns {string} document URL or empty string if bmak.enReadDocUrl is false
+     */
     getdurl: function() {
       return bmak.enReadDocUrl ? document.URL.replace(/\\|"/g, "") : "";
     },
     
-    /*
-      Returns a random 5 character sequence of numbers and letters
-    */
+    /**
+     * Returns a random 5 character sequence of numbers and letters
+     * @returns {string} a random 5 character sequence of numbers and letters
+     */
     x1: function() {
       return Math.floor(16777216 * (1 + Math.random())).toString(36);
     },
@@ -1750,14 +1785,15 @@ var _cf = _cf || [],
       return t;
     },
     
-    /*
-      Used to return the value of the cookie name stored in bmak.ckie (_abck cookie)
-
-      Traverses all cookies and if the cookie name matches the parameter and if
-      the cookie value contains a ~ then return the cookie value.
-
-      Return false otherwise
-    */
+    /**
+     * Used to return the value of the cookie name stored in bmak.ckie (_abck cookie)
+     * 
+     * Traverses all cookies and if the cookie name matches the parameter and if
+     * the cookie value contains a ~ then return the cookie value.
+     * 
+     * Return false otherwise
+     * @returns {string|boolean}
+     */
     cookie_chk_read: function(t) {
       if (document.cookie)
         var a = t + "=";
@@ -1773,10 +1809,10 @@ var _cf = _cf || [],
       return !1;
     },
     
-    /*
-      This functions is where the sensor_data for the outgoing cookie
-      gets crafted.
-    */
+    /**
+     * This functions is where the sensor_data for the outgoing cookie
+     * gets crafted.
+     */
     bpd: function() {
       bmak.sd_debug("<bpd>");
       var t = 0;
@@ -1869,9 +1905,13 @@ var _cf = _cf || [],
 
       bmak.sd_debug("</bpd>");
     },
-    // t = bmak.cs, a = api_public_key
-    // t = 0a46G5m17Vrp4o4c
-    // a = afSbep8yjnZUjq3aL010jO15Sawj2VZfdYK8uY90uxq
+    
+    /**
+     * 
+     * @param {string} t 
+     * @param {string} a 
+     * @returns {string}
+     */
     od: function(t, a) {
       try {
         t = String(t), a = String(a);
@@ -1906,9 +1946,10 @@ var _cf = _cf || [],
       return t > a && t <= e && (t += n % (e - a)) > e && (t = t - e + a), t;
     },
     
-    /*
-      Triggered on visibility change.
-    */
+    /**
+     * Triggered on visibility change.
+     * @param {*} t 
+     */
     lvc: function(t) {
       try {
         // If visibility change count is less than the limit (100)
@@ -1926,9 +1967,9 @@ var _cf = _cf || [],
       } catch (t) {}
     },
     
-    /*
-      Gets triggered on "visibilitychange", "mozvisibilitychange", "msvisibilitychange", and "webkitvisibilitychange"
-    */
+    /**
+     * Gets triggered on "visibilitychange", "mozvisibilitychange", "msvisibilitychange", and "webkitvisibilitychange"
+     */
     hvc: function() {
       try {
         var t = 1;
@@ -1945,14 +1986,14 @@ var _cf = _cf || [],
       void 0 !== document.hidden ? (bmak.hn = "hidden", bmak.vc = "visibilitychange") : void 0 !== document.mozHidden ? (bmak.hn = "mozHidden", bmak.vc = "mozvisibilitychange") : void 0 !== document.msHidden ? (bmak.hn = "msHidden", bmak.vc = "msvisibilitychange") : void 0 !== document.webkitHidden && (bmak.hn = "webkitHidden", bmak.vc = "webkitvisibilitychange"), document.addEventListener ? "unk" != bmak.hn && document.addEventListener(bmak.vc, bmak.hvc, !0) : document.attachEvent && "unk" != bmak.hn && document.attachEvent(bmak.vc, bmak.hvc), window.onblur = bmak.hb, window.onfocus = bmak.hf;
     },
     
-    /*
-      Start tracking device orientation and device motion
-      and then setup event listeners for other event
-      tracking (e.g: key tracking, mouse tracking)
-
-      This function calls the startdoadma function initially
-      and then on a 3 second interval.
-    */
+    /**
+     * Start tracking device orientation and device motion
+     * and then setup event listeners for other event
+     * tracking (e.g: key tracking, mouse tracking)
+     *
+     * This function calls the startdoadma function initially
+     * and then on a 3 second interval.
+     */
     startTracking: function() {
       bmak.startdoadma();
 
@@ -2004,29 +2045,30 @@ var _cf = _cf || [],
       bmak.firstLoad = !1;
     },
     
-    /*
-      Checks if a character is a part of the extended
-      ASCII code range. If it isn't return 0 otherwise
-      return the character code.
-
-      see: https://www.ascii-code.com/
-
-      t: String to check
-      a: Index of character you want to check
-    */
+    /**
+     * Checks if a character is a part of the extended
+     * ASCII code range. If it isn't return 0 otherwise
+     * return the character code.
+     * 
+     * @see: https://www.ascii-code.com/
+     * @param {string} t string to check
+     * @param {number} a index of character you want to check
+     * @returns {number}
+     */
     gb: function(t, a) {
       var e = t.charCodeAt(a);
       return e = e > 255 ? 0 : e;
     },
     
-    /*
-      Base64 encode a string.
-
-      If the btoa function doesn't exist then it uses
-      its own.
-
-      see: https://developer.mozilla.org/en-US/docs/Web/API/btoa
-    */
+    /**
+     * Base64 encode a string.
+     * 
+     * If the btoa function doesn't exist then it uses
+     * its own.
+     * 
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/btoa
+     * @returns
+     */
     encode: function(t) {
       if ("undefined" != typeof btoa) return btoa(t);
 
@@ -2034,7 +2076,11 @@ var _cf = _cf || [],
 
       return t.length % 3 == 1 && (a = bmak.gb(t, s), o = a >> 2, m = (3 & a) << 4, b = b + c.charAt(o) + c.charAt(m) + "=="), t.length % 3 == 2 && (a = bmak.gb(t, s), e = bmak.gb(t, s + 1), o = a >> 2, m = ((3 & a) << 4) + (e >> 4), r = (15 & e) << 2, b = b + c.charAt(o) + c.charAt(m) + c.charAt(r) + "="), b;
     },
-    // IE 9 or less check.
+    
+    /**
+     * IE 9 or less check.
+     * @returns {boolean}
+     */
     ie9OrLower: function() {
       try {
         if ("string" == typeof navigator.appVersion && -1 != navigator.appVersion.indexOf("MSIE")) {
@@ -2044,9 +2090,16 @@ var _cf = _cf || [],
 
       return !1;
     },
-    // Returns nothing.
+    
+    /**
+     * Returns nothing.
+     * @param {*} t 
+     */
     parse_gp: function(t) {},
-    // Not called in script.
+    
+    /**
+     * Not called in script.
+     */
     call_gp: function() {
       var t;
       void 0 !== window.XMLHttpRequest ? t = new XMLHttpRequest() : void 0 !== window.XDomainRequest ? (t = new XDomainRequest(), t.onload = function() {
@@ -2055,7 +2108,12 @@ var _cf = _cf || [],
         t.readyState > 3 && bmak.parse_gp && bmak.parse_gp(t);
       }, t.send();
     },
-    // Not called in script.
+    
+    /**
+     * Not called in script.
+     * @param {*} t 
+     * @param {*} a 
+     */
     apicall: function(t, a) {
       var e;
       e = window.XDomainRequest ? new XDomainRequest() : window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"), e.open("POST", t, a);
@@ -2064,7 +2122,13 @@ var _cf = _cf || [],
       var o = "{\"session_id\" : \"" + bmak.session_id + "\",\"sensor_data\" : \"" + bmak.sensor_data + "\"" + bmak.auth + "}";
       e.send(o);
     },
-    // Main function for sending Sensor Data to API.
+    
+    /**
+     * Main function for sending Sensor Data to API.
+     * @param {*} t 
+     * @param {*} a 
+     * @param {*} e 
+     */
     apicall_bm: function(t, a, e) {
       var n;
       void 0 !== window.XMLHttpRequest ? n = new XMLHttpRequest() : void 0 !== window.XDomainRequest ? (n = new XDomainRequest(), n.onload = function() {
@@ -2188,11 +2252,13 @@ var _cf = _cf || [],
       return unescape(encodeURIComponent(t));
     },
     
-    /*
-      Mini SHA 256 function.
-      Takes in the string to hash
-      Returns the hashed output as a byte array
-    */
+    /**
+     * Mini SHA 256 function.
+     * Takes in the string to hash
+     * Returns the hashed output as a byte array
+     * @param {*} t
+     * @returns
+     */
     mn_s: function(t) {
       var a = [1116352408, 1899447441, 3049323471, 3921009573, 961987163, 1508970993, 2453635748, 2870763221, 3624381080, 310598401, 607225278, 1426881987, 1925078388, 2162078206, 2614888103, 3248222580, 3835390401, 4022224774, 264347078, 604807628, 770255983, 1249150122, 1555081692, 1996064986, 2554220882, 2821834349, 2952996808, 3210313671, 3336571891, 3584528711, 113926993, 338241895, 666307205, 773529912, 1294757372, 1396182291, 1695183700, 1986661051, 2177026350, 2456956037, 2730485921, 2820302411, 3259730800, 3345764771, 3516065817, 3600352804, 4094571909, 275423344, 430227734, 506948616, 659060556, 883997877, 958139571, 1322822218, 1537002063, 1747873779, 1955562222, 2024104815, 2227730452, 2361852424, 2428436474, 2756734187, 3204031479, 3329325298],
         e = 1779033703,
@@ -2227,7 +2293,10 @@ var _cf = _cf || [],
 
       return [e >> 24 & 255, e >> 16 & 255, e >> 8 & 255, 255 & e, n >> 24 & 255, n >> 16 & 255, n >> 8 & 255, 255 & n, o >> 24 & 255, o >> 16 & 255, o >> 8 & 255, 255 & o, m >> 24 & 255, m >> 16 & 255, m >> 8 & 255, 255 & m, r >> 24 & 255, r >> 16 & 255, r >> 8 & 255, 255 & r, i >> 24 & 255, i >> 16 & 255, i >> 8 & 255, 255 & i, c >> 24 & 255, c >> 16 & 255, c >> 8 & 255, 255 & c, b >> 24 & 255, b >> 16 & 255, b >> 8 & 255, 255 & b];
     },
-    // Initializes Akamai Proof of Work challenges
+    
+    /**
+     * Initializes Akamai Proof of Work challenges
+     */
     mn_init: function() {
       var t = 200;
       bmak.pstate && (t = 100), setInterval(bmak.mn_poll, t);
@@ -2258,21 +2327,23 @@ var _cf = _cf || [],
       return bmak.mn_al.join(",") + ";" + bmak.mn_tcl.join(",") + ";" + bmak.mn_il.join(",") + ";" + bmak.mn_lg.join(",") + ";";
     },
     
-    /*
-    This function takes in an array of numbers and converts it to a hex string.
-    All instances of this function are called with the result of bmak.mn_s (SHA256) as the parameter
-
-    Example:
-      const hashed_abc = bmak.mn_s("abc"); // [186,120,22,191,143,1,207,234,65,65,64,222,93,174,34,35,176,3,97,163,150,23,122,156,180,16,255,97,242,0,21,173]
-      const hashed_abc_hex = bmak.ats(hashed_abc); // ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-
-    Original Function:
-      ats: function(t) {
-        for (var a = "", e = 0; e < t.length; e++) a += 2 == t[e].toString(16).length ? t[e].toString(16) : "0" + t[e].toString(16);
-
-        return a;
-      }
-    */
+    /**
+     * This function takes in an array of numbers and converts it to a hex string.     
+     * All instances of this function are called with the result of bmak.mn_s (SHA256) as the parameter
+     *
+     * Example:      
+     *   const hashed_abc = bmak.mn_s("abc"); // [186,120,22,191,143,1,207,234,65,65,64,222,93,174,34,35,176,3,97,163,150,23,122,156,180,16,255,97,242,0,21,173]     
+     *   const hashed_abc_hex = bmak.ats(hashed_abc); // ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+     *
+     * Original Function:     
+     *   ats: function(t) {     
+     *      for (var a = "", e = 0; e < t.length; e++) a += 2 == t[e].toString(16).length ? t[e].toString(16) : "0" + t[e].toString(16);
+     *
+     *      return a;    
+     *   }
+     * @param {*} t 
+     * @returns 
+     */
     ats: function(t) {
       var a = "";
       for (var e = 0; e < t.length; e++) {
@@ -2408,10 +2479,12 @@ if (function(t) {
       return e;
     }, 
     
-    /*
-      Canvas Fingerprinting
-      see: https://browserleaks.com/canvas#how-does-it-work
-    */
+    /**
+     * Canvas Fingerprinting
+     * @see https://browserleaks.com/canvas#how-does-it-work
+     * @param {*} t 
+     * @returns 
+     */
     a.canvas = function(t) {
       try {
         if (void 0 !== a.cache.canvas) return a.cache.canvas;
@@ -2511,61 +2584,62 @@ if (function(t) {
       return n.join(",");
     },
     
-    /*
-      Font fingerprinting.
-
-      Render serif, sans-serif, and monospace font
-      in a span and collect the offsetWidth and
-      offsetHeights.
-
-      Once we gather this information, we can render
-      a list of various fonts with serif, sans-serif,
-      and monospace as fallbacks.
-
-      If we compare the offsetWidth and offsetHeights
-      of these new elements to the ones we collected
-      initially we can determine if the user has the
-      font installed on their system.
-      
-      Example from my M1 13 inch Macbook Air:
-      
-      serif:
-        offsetWidth: 1653
-        offsetHeight: 105
-
-      sans-serif:
-        offsetWidth: 1779
-        offsetHeight: 104
-
-      monospace:
-        offsetWidth: 2160
-        offsetHeight: 104
-
-      If we test a font we already have, lets say Geneva, we would define the CSS as:
-      font-family: "Geneva", serif; or 
-      font-family: "Geneva", sans-serif; or
-      font-family: "Geneva", monospace;
-      
-      Geneva:
-        offsetWidth: 2005
-        offsetHeight: 113
-
-      These numbers don't align with any of the fallback values so that means the font exists
-      on our machine..
-
-      However, let's try a font we don't have:
-
-      Lobster:
-        offsetWidth: 1653
-        offsetHeight: 105
-
-      These values match the serif font values which means it fell back because the font doesn't exist.
-
-      If this happens, push the index of the font into an array, sort it, join it by commas and
-      that's what this function returns.
-
-      see: https://digitalworks.union.edu/cgi/viewcontent.cgi?article=3374&context=theses
-    */
+    /**
+     * Font fingerprinting.
+     * 
+     * Render serif, sans-serif, and monospace font
+     * in a span and collect the offsetWidth and
+     * offsetHeights.
+     * 
+     * Once we gather this information, we can render
+     * a list of various fonts with serif, sans-serif,
+     * and monospace as fallbacks.
+     * 
+     * If we compare the offsetWidth and offsetHeights
+     * of these new elements to the ones we collected
+     * initially we can determine if the user has the
+     * font installed on their system.
+     * 
+     * Example from my M1 13 inch Macbook Air:
+     * 
+     * serif:
+     *   offsetWidth: 1653
+     *   offsetHeight: 105
+     * 
+     * sans-serif:
+     *   offsetWidth: 1779
+     *   offsetHeight: 104
+     * 
+     * monospace:
+     *   offsetWidth: 2160
+     *   offsetHeight: 104
+     * 
+     * If we test a font we already have, lets say Geneva, we would define the CSS as:
+     * font-family: "Geneva", serif; or 
+     * font-family: "Geneva", sans-serif; or
+     * font-family: "Geneva", monospace;
+     * 
+     * Geneva:
+     *   offsetWidth: 2005
+     *   offsetHeight: 113
+     * 
+     * These numbers don't align with any of the fallback values so that means the font exists
+     * on our machine..
+     * 
+     * However, let's try a font we don't have:
+     * 
+     * Lobster:
+     *   offsetWidth: 1653
+     *   offsetHeight: 105
+     * 
+     * These values match the serif font values which means it fell back because the font doesn't exist.
+     * 
+     * If this happens, push the index of the font into an array, sort it, join it by commas and
+     * that's what this function returns.
+     * 
+     * @see https://digitalworks.union.edu/cgi/viewcontent.cgi?article=3374&context=theses
+     * @returns 
+     */
     a.fonts = function() {
       var t = [];
 
@@ -2606,10 +2680,10 @@ if (function(t) {
       return t.join(",");
     },
     
-    /*
-      Check for WebRTC.
-      Doesn't exist in IE. Added in Safari 11
-    */
+    /**
+     * Check for WebRTC.
+     * Doesn't exist in IE. Added in Safari 11
+     */
     a.webrtcKey = function() {
       return "function" == typeof window.RTCPeerConnection || "function" == typeof window.mozRTCPeerConnection || "function" == typeof window.webkitRTCPeerConnection;
     }, a.indexedDbKey = function() {

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -94,11 +94,12 @@ var _cf = _cf || [],
     mn_lg: [],
     loap: 1,
     dcs: 0,
-    /*
-      Initialize / Reset variables.
-      One of the first functions to get called.
-      Also gets called in get_telemetry
-    */
+    
+    /**
+     * Initialize / Reset variables.
+     * One of the first functions to get called.
+     * Also gets called in get_telemetry
+     */
     ir: function() {
       bmak.start_ts = Date.now ? Date.now() : +new Date();
       bmak.kact = "";
@@ -144,12 +145,15 @@ var _cf = _cf || [],
       bmak.weh = "";
       bmak.wl = 0;
     },
-    /*
-      Date.now()
-    */
+    
+    /**
+     * Returns the Date in a Unix time format https://en.wikipedia.org/wiki/Unix_time
+     * @returns {number} Unix time (timestamp), e.g: 1631080958
+     */
     get_cf_date: function() {
       return Date.now ? Date.now() : +new Date();
     },
+    
     sd_debug: function(t) {
       if (!bmak.js_post) {
         var a = t;
@@ -160,6 +164,7 @@ var _cf = _cf || [],
     pi: function(t) {
       return parseInt(t);
     },
+    
     /*
       Return User Agent
     */
@@ -224,6 +229,7 @@ var _cf = _cf || [],
         b = -1;
       }
 
+      
       /*
         parseInt(start timestamp / 4064256)
         
@@ -242,6 +248,7 @@ var _cf = _cf || [],
         k = d + "";
       return k = k.slice(0, 11) + s, bmak.gbrv(), bmak.get_browser(), bmak.bc(), bmak.bmisc(), t + ",uaend," + bmak.xagg + "," + bmak.psub + "," + bmak.lang + "," + bmak.prod + "," + bmak.plen + "," + bmak.pen + "," + bmak.wen + "," + bmak.den + "," + bmak.z1 + "," + bmak.d3 + "," + n + "," + o + "," + m + "," + r + "," + c + "," + i + "," + b + "," + bmak.bd() + "," + a + "," + k + "," + e + "," + bmak.brv + ",loc:" + bmak.loc;
     },
+    
     /*
 
     Original Function:
@@ -276,6 +283,7 @@ var _cf = _cf || [],
         bmak.plen = -1;
       }
     },
+    
     /*
       Check if the user is using the Brave browser.
       The navigator.brave property only exists on
@@ -294,6 +302,7 @@ var _cf = _cf || [],
         bmak.brv = 0;
       });
     },
+    
     /*
       Function crafts a bit field that determines whether
       various window functions exist.
@@ -358,6 +367,7 @@ var _cf = _cf || [],
 
       bmak.xagg = t + (a << 1) + (e << 2) + (n << 3) + (o << 4) + (m << 5) + (r << 6) + (i << 7) + (k << 8) + (l << 9) + (c << 10) + (b << 11) + (d << 12) + (s << 13);
     },
+    
     /*
       Check for browser driver automation:
       https://www.selenium.dev/selenium
@@ -365,6 +375,7 @@ var _cf = _cf || [],
     bmisc: function() {
       // _phantom https://phantomjs.org/
       bmak.pen = window._phantom ? 1 : 0;
+      
       /*
         window.webdriver property is true when in:
       Chrome
@@ -407,6 +418,7 @@ var _cf = _cf || [],
       t.push("wrc:" + b);
       var d = "mozInnerScreenY" in window ? window.mozInnerScreenY : 0;
       t.push("isc:" + d);
+      
       /*
         Rough day identifier for start timestamp(bmak.start_ts).
 
@@ -429,6 +441,7 @@ var _cf = _cf || [],
       var u = "FileReader" in window ? 1 : 0;
       return t.push("x12:" + u), t.join(",");
     },
+    
     /*
       Create a bit field checking for the existence of the following properties
       0: navigator.credentials
@@ -476,6 +489,7 @@ var _cf = _cf || [],
         return 0;
       }
     },
+    
     /*
     This function gets an average of performance metrics by
     running various Math and JSON functions several times.
@@ -511,6 +525,7 @@ var _cf = _cf || [],
         bmak.mr = "exception";
       }
     },
+    
     /*
       Checks for a series of properties that only exist while using
       browser driver automation libraries. 
@@ -543,6 +558,7 @@ var _cf = _cf || [],
       // default values to avoid being detected as a bot
       // return "0,0,0,0,1,0,0"
     },
+    
     /*
       Mouse events.
 
@@ -555,6 +571,7 @@ var _cf = _cf || [],
     */
     cma: function(t, a) {
       try {
+        
         /*
           If this function is being triggered by: 
           a mousemove event and the mouse events is less than the mouse move event limit (100)
@@ -585,6 +602,7 @@ var _cf = _cf || [],
         1 == a ? bmak.mme_cnt++ : bmak.mduce_cnt++, bmak.me_cnt++, bmak.js_post && 3 == a && (bmak.aj_type = 1, bmak.bpd(), bmak.pd(!0), bmak.ce_js_post = 1);
       } catch (t) {}
     },
+    
     /*
       Another one of Akamai's obfuscated ways of
       return current timestamp in milliseconds.
@@ -602,6 +620,7 @@ var _cf = _cf || [],
         o = 0;
       return "function" == typeof n && (o = n()), o;
     },
+    
     /*
       Queries a bunch of permissions and maps into an array that
       states whether the permission was
@@ -667,6 +686,7 @@ var _cf = _cf || [],
         bmak.nav_perm = 7;
       }
     },
+    
     /*
       This function handles pointer events.
       Pointer events can be triggered by pen/stylus
@@ -684,6 +704,7 @@ var _cf = _cf || [],
         if (1 == a && bmak.pme_cnt < bmak.pme_cnt_lmt || 1 != a && bmak.pduce_cnt < bmak.pduce_cnt_lmt) {
           var n = t || window.event;
 
+          
           /*
             Only run this if the user is not using a mouse
             (is using a pen or touchscreen)
@@ -704,6 +725,7 @@ var _cf = _cf || [],
         1 == a ? bmak.pme_cnt++ : bmak.pduce_cnt++, bmak.pe_cnt++, bmak.js_post && 3 == a && e && (bmak.aj_type = 2, bmak.bpd(), bmak.pd(!0), bmak.ce_js_post = 1);
       } catch (t) {}
     },
+    
     /*
       Takes in a string as a parameter
       Iterates over the string
@@ -737,6 +759,7 @@ var _cf = _cf || [],
     ff: function(t) {
       return String.fromCharCode(t);
     },
+    
     /*
       Distance formula
       https://www.varsitytutors.com/hotmath/hotmath_help/topics/distance-formula-in-3d
@@ -764,6 +787,7 @@ var _cf = _cf || [],
 
       bmak.o9 = a * e;
     },
+    
     /*
       The t parameter is the start timestamp (start_ts)
       Original function:
@@ -791,6 +815,7 @@ var _cf = _cf || [],
 
       return [a, bmak.cal_dis(o)];
     },
+    
     /*
       Text rendering based fingerprinting.
       By rendering various fonts and taking note of device pixel ratio
@@ -822,6 +847,7 @@ var _cf = _cf || [],
       // whereas 2 indicates HiDPI/Retina.
       bmak.fmz = "devicePixelRatio" in window && void 0 !== window.devicePixelRatio ? window.devicePixelRatio : -1;
     },
+    
     /*
     WebGL based detections through the capturing of GPU and vendor
     + the collection of hashed supported web extensions.
@@ -874,6 +900,7 @@ var _cf = _cf || [],
         bmak.wl = 0;
       }
     },
+    
     /*
       Can be used to fingerprint and determine what device/browser
       a user is using.
@@ -903,6 +930,7 @@ var _cf = _cf || [],
         } else bmak.ssh = "0";
       } else bmak.ssh = "n";
     },
+    
     /*
       Create a bit field checking for the existence of any
       browser automation drivers
@@ -959,6 +987,7 @@ var _cf = _cf || [],
         return 0;
       }
     },
+    
     /*
       Checks if navigator.webdriver is true.
       https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver
@@ -976,6 +1005,7 @@ var _cf = _cf || [],
         return 0;
       }
     },
+    
     /*
       Accumulate the ascii values of each character of 
       "name" or "id" attribute
@@ -1026,6 +1056,7 @@ var _cf = _cf || [],
       var e = a.getAttribute("type");
       return 1 == (null == e ? -1 : bmak.get_type(e)) && bmak.fidcnt > 12 && -2 == t ? 1 : 0;
     },
+    
     /*
       Key event function
       Gets called on 
@@ -1061,6 +1092,7 @@ var _cf = _cf || [],
         o && e && bmak.ke_cnt++, !bmak.js_post || 1 != a || 13 != n && 9 != n || (bmak.aj_type = 3, bmak.bpd(), bmak.pd(!0), bmak.ce_js_post = 1);
       } catch (t) {}
     },
+    
     /*
       Touch events function
       Get called on:
@@ -1084,6 +1116,7 @@ var _cf = _cf || [],
         1 == a ? bmak.tme_cnt++ : bmak.tduce_cnt++, bmak.te_cnt++, bmak.js_post && 2 == a && bmak.aj_indx_tact < bmak.aj_lmt_tact && (bmak.aj_type = 5, bmak.bpd(), bmak.pd(!0), bmak.ce_js_post = 1, bmak.aj_indx_tact++);
       } catch (t) {}
     },
+    
     /*
       Parse the parameter as a float and only
       return the float with a precision of 2
@@ -1139,6 +1172,7 @@ var _cf = _cf || [],
         bmak.js_post && bmak.dme_cnt > 1 && bmak.aj_indx_dmact < bmak.aj_lmt_dmact && (bmak.aj_type = 7, bmak.bpd(), bmak.pd(!0), bmak.ce_js_post = 1, bmak.aj_indx_dmact++), bmak.dma_throttle++;
       } catch (t) {}
     },
+    
     /*
       Get type of HTML input element
       return 0 for: "text", "search", "url", "email", "tel", "number"
@@ -1148,6 +1182,7 @@ var _cf = _cf || [],
     get_type: function(t) {
       return t = t.toLowerCase(), "text" == t || "search" == t || "url" == t || "email" == t || "tel" == t || "number" == t ? 0 : "password" == t ? 1 : 2;
     },
+    
     /*
       Return -1 if null otherwise return parameter
     */
@@ -1174,6 +1209,7 @@ var _cf = _cf || [],
 
       return null == bmak.ins && (bmak.ins = a), bmak.cns = a, t;
     },
+    
     /*
       Adds event listeners for device orientation & device motion
     */
@@ -1249,6 +1285,7 @@ var _cf = _cf || [],
     get_telemetry: function() {
       return bmak.bpd(), bmak.ir(), bmak.sensor_data;
     },
+    
     /*
       Get the document URL and remove escape / quotation mark if exists.
       Return empty string if bmak.enReadDocUrl is false
@@ -1256,6 +1293,7 @@ var _cf = _cf || [],
     getdurl: function() {
       return bmak.enReadDocUrl ? document.URL.replace(/\\|"/g, "") : "";
     },
+    
     /*
       Returns a random 5 character sequence of numbers and letters
     */
@@ -1279,6 +1317,7 @@ var _cf = _cf || [],
 
       return t;
     },
+    
     /*
       Used to return the value of the cookie name stored in bmak.ckie (_abck cookie)
 
@@ -1301,6 +1340,7 @@ var _cf = _cf || [],
         }
       return !1;
     },
+    
     /*
       This functions is where the sensor_data for the outgoing cookie
       gets crafted.
@@ -1332,6 +1372,7 @@ var _cf = _cf || [],
           l = k(80) + k(105) + k(90) + k(116) + k(69), // PiZtE
           u = bmak.jrs(bmak.start_ts),
           _ = bmak.get_cf_date() - bmak.start_ts,
+          
           /*
             Week identifier for start timestamp(bmak.start_ts).
 
@@ -1421,6 +1462,7 @@ var _cf = _cf || [],
 
       return t;
     },
+    
     /*
 
     Original Function:
@@ -1431,6 +1473,7 @@ var _cf = _cf || [],
     rir: function(t, a, e, n) {
       return t > a && t <= e && (t += n % (e - a)) > e && (t = t - e + a), t;
     },
+    
     /*
       Triggered on visibility change.
     */
@@ -1450,6 +1493,7 @@ var _cf = _cf || [],
         bmak.vc_cnt++;
       } catch (t) {}
     },
+    
     /*
       Gets triggered on "visibilitychange", "mozvisibilitychange", "msvisibilitychange", and "webkitvisibilitychange"
     */
@@ -1468,6 +1512,7 @@ var _cf = _cf || [],
     rve: function() {
       void 0 !== document.hidden ? (bmak.hn = "hidden", bmak.vc = "visibilitychange") : void 0 !== document.mozHidden ? (bmak.hn = "mozHidden", bmak.vc = "mozvisibilitychange") : void 0 !== document.msHidden ? (bmak.hn = "msHidden", bmak.vc = "msvisibilitychange") : void 0 !== document.webkitHidden && (bmak.hn = "webkitHidden", bmak.vc = "webkitvisibilitychange"), document.addEventListener ? "unk" != bmak.hn && document.addEventListener(bmak.vc, bmak.hvc, !0) : document.attachEvent && "unk" != bmak.hn && document.attachEvent(bmak.vc, bmak.hvc), window.onblur = bmak.hb, window.onfocus = bmak.hf;
     },
+    
     /*
       Start tracking device orientation and device motion
       and then setup event listeners for other event
@@ -1526,6 +1571,7 @@ var _cf = _cf || [],
       }
       bmak.firstLoad = !1;
     },
+    
     /*
       Checks if a character is a part of the extended
       ASCII code range. If it isn't return 0 otherwise
@@ -1540,6 +1586,7 @@ var _cf = _cf || [],
       var e = t.charCodeAt(a);
       return e = e > 255 ? 0 : e;
     },
+    
     /*
       Base64 encode a string.
 
@@ -1708,6 +1755,7 @@ var _cf = _cf || [],
     encode_utf8: function(t) {
       return unescape(encodeURIComponent(t));
     },
+    
     /*
       Mini SHA 256 function.
       Takes in the string to hash
@@ -1777,6 +1825,7 @@ var _cf = _cf || [],
     mn_pr: function() {
       return bmak.mn_al.join(",") + ";" + bmak.mn_tcl.join(",") + ";" + bmak.mn_il.join(",") + ";" + bmak.mn_lg.join(",") + ";";
     },
+    
     /*
     This function takes in an array of numbers and converts it to a hex string.
     All instances of this function are called with the result of bmak.mn_s (SHA256) as the parameter
@@ -1926,6 +1975,7 @@ if (function(t) {
 
       return e;
     }, 
+    
     /*
       Canvas Fingerprinting
       see: https://browserleaks.com/canvas#how-does-it-work
@@ -2028,6 +2078,7 @@ if (function(t) {
 
       return n.join(",");
     },
+    
     /*
       Font fingerprinting.
 
@@ -2122,6 +2173,7 @@ if (function(t) {
 
       return t.join(",");
     },
+    
     /*
       Check for WebRTC.
       Doesn't exist in IE. Added in Safari 11
@@ -2184,7 +2236,6 @@ if (function(t) {
     bmak.startTracking();
     bmak.tst = bmak.get_cf_date() - bmak.t_tst;
     bmak.disFpCalOnTimeout || setTimeout(bmak.calc_fp, 500);
-
 
     /*
       Run the performance metric function 3 times.

--- a/akamai/1.7.js
+++ b/akamai/1.7.js
@@ -5,6 +5,8 @@ var _cf = _cf || [],
   /**
    * @namespace bmak
    * @version 1.7
+   * @property {string} wen                     - Webdriver activated
+   * @property {string} den                     - Headless Chrome
    */
   bmak = { // Old declaration ` bmak && bmak.hasOwnProperty("ver") && bmak.hasOwnProperty("sed") ? bmak : ...`
     /**
@@ -141,6 +143,7 @@ var _cf = _cf || [],
      */
     disFpCalOnTimeout: 0,
     /**
+     * A bit field that store the window functions that exists in your browser
      * @type {number}
      */
     xagg: -1,
@@ -160,19 +163,25 @@ var _cf = _cf || [],
     /**
      * Browser build number
      * @type {string}
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/productSub
      */
     psub: "-",
     /**
      * User's browser's preferred language
      * @type {string}
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
      */
     lang: "-",
     /**
+     * Always 'Gecko'
      * @type {string}
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/product
      */
     prod: "-",
     /**
+     * Legacy browser plugins. Not to be confused with extensions.
      * @type {number}
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/plugins
      */
     plen: -1,
     /**
@@ -200,6 +209,10 @@ var _cf = _cf || [],
      * @type {string}
      */
     hn: "unk",
+    /**
+     * Creates a rough estimate of the hour identifier for start timestamp
+     * @type {number}
+     */
     z1: 0,
     o9: 0,
     vc: "",
@@ -507,7 +520,7 @@ var _cf = _cf || [],
          */
         k = d + "";
       
-        // ${userAgent},uaend,${functionsInBrowser},${buildNumber},${language},Gecko,${legacyPlugins}
+        // ${userAgent},uaend,${functionsInBrowser},${buildNumber},${language},Gecko,${legacyPlugins},${phantom},${webdriver},${headless},${timestampHour},${?},${screen.availWidth},${screen.availHeight},${screen.width},${screen.height},${window.innerWidth},${innerHeight},${outerWidth}, TODO: bmak.bd() + "," + a + "," + k + "," + e + "," + bmak.brv + ",loc:" + bmak.loc
       return k = k.slice(0, 11) + s, bmak.gbrv(), bmak.get_browser(), bmak.bc(), bmak.bmisc(), t + ",uaend," + bmak.xagg + "," + bmak.psub + "," + bmak.lang + "," + bmak.prod + "," + bmak.plen + "," + bmak.pen + "," + bmak.wen + "," + bmak.den + "," + bmak.z1 + "," + bmak.d3 + "," + n + "," + o + "," + m + "," + r + "," + c + "," + i + "," + b + "," + bmak.bd() + "," + a + "," + k + "," + e + "," + bmak.brv + ",loc:" + bmak.loc;
     },
     


### PR DESCRIPTION
Switching to JSDoc could help maintaining the documentation in a more readable way.
https://jsdoc.app/about-getting-started.html

### OLD
```js
/*
   Date.now()
*/
get_cf_date: function() {
   return Date.now ? Date.now() : +new Date();
}
```

### NEW
```js
/**
  * Returns the Date in a Unix time format https://en.wikipedia.org/wiki/Unix_time
  * @returns {number} Unix time (timestamp), e.g: 1631080958
*/
get_cf_date: function() {
   return Date.now ? Date.now() : +new Date();
}
```